### PR TITLE
feat: Add Frontend Selection and Jupyter Support, add Renku Buildpacks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,11 @@ BUILDERS := $(shell find builders -maxdepth 1 -type d -not -path "builders" -pri
 # Define the builder image to use
 BUILDER_IMAGE ?= $(word 1, $(BUILDERS))
 
+# Define the allowed frontends
+FRONTENDS := jupyterlab vscodium
+
 # Define the frontend image to use
-FRONTEND ?= jupyterlab
+FRONTEND ?= $(word 1, $(FRONTENDS))
 
 SAMPLE_IMAGE ?= $(word 1, $(SAMPLE_IMAGES))
 
@@ -26,7 +29,7 @@ buildpacks:
 	@echo "Building buildpacks..."
 	@for bp in $(BUILDPACKS); do \
 		echo "  Building buildpack: $$bp"; \
-		pack buildpack package $$bp --config buildpacks/$$bp/package.toml --target "linux"; \
+		pack buildpack package $$bp --config buildpacks/$$bp/package.toml --target "linux/amd64"; \
 	done
 
 builders:

--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,23 @@
 # Buildpacks directory (assuming each subdirectory contains a buildpack)
 BUILDPACKS := $(shell find buildpacks -maxdepth 1 -type d -not -path "buildpacks" -printf "%P ")
 
-.PHONY: all buildpacks
+# Builders directory (assuming each subdirectory contains a builder definition)
+BUILDERS := $(shell find builders -maxdepth 1 -type d -not -path "builders" -printf "%P ")
 
-all: buildpacks
+.PHONY: all buildpacks builders
+
+all: buildpacks builders
 
 buildpacks:
 	@echo "Building buildpacks..."
 	@for bp in $(BUILDPACKS); do \
 		echo "  Building buildpack: $$bp"; \
 		pack buildpack package $$bp --config buildpacks/$$bp/package.toml --target "linux"; \
+	done
+
+builders:
+	@echo "Building builders..."
+	@for builder in $(BUILDERS); do \
+		echo "  Building builder: $$builder"; \
+		pack builder create $$builder --config builders/$$builder/builder.toml --target "linux"; \
 	done

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+
+# Makefile
+
+# Buildpacks directory (assuming each subdirectory contains a buildpack)
+BUILDPACKS := $(shell find buildpacks -maxdepth 1 -type d -not -path "buildpacks" -printf "%P ")
+
+.PHONY: all buildpacks
+
+all: buildpacks
+
+buildpacks:
+	@echo "Building buildpacks..."
+	@for bp in $(BUILDPACKS); do \
+		echo "  Building buildpack: $$bp"; \
+		pack buildpack package $$bp --config buildpacks/$$bp/package.toml --target "linux"; \
+	done

--- a/Makefile
+++ b/Makefile
@@ -33,16 +33,16 @@ builders:
 	@echo "Building builders..."
 	@for builder in $(BUILDERS); do \
 		echo "  Building builder: $$builder"; \
-		pack builder create $$builder --config builders/$$builder/builder.toml --target "linux"; \
+		pack builder create $$builder --config builders/$$builder/builder.toml --target "linux/amd64"; \
 	done
 
 samples:
 	@echo "Building sample images..."
 	@for image in $(SAMPLE_IMAGES); do \
 		echo "  Building image: $$image with $(BUILDER_IMAGE)"; \
-		pack build $$image --path samples/$$image --env BP_REQUIRES=$(FRONTEND) --builder $(BUILDER_IMAGE) --platform "linux"; \
+		pack build $$image-$(FRONTEND) --path samples/$$image --env BP_REQUIRES=$(FRONTEND) --builder $(BUILDER_IMAGE) --platform "linux"; \
 	done
 
 run:
-	@echo "Running sample image : $(SAMPLE_IMAGE)"
-	docker run -it --rm --publish 8000:8000 --entrypoint $(FRONTEND) $(SAMPLE_IMAGE):latest
+	@echo "Running sample image : $(SAMPLE_IMAGE)-$(FRONTEND)"
+	docker run -it --rm --publish 8000:8000 --entrypoint $(FRONTEND) $(SAMPLE_IMAGE)-$(FRONTEND):latest

--- a/README.md
+++ b/README.md
@@ -1,2 +1,87 @@
 # renku-frontend-buildpacks
-A collection of Buildpacks that inject different frontends for Renku sessions
+
+This project provides a set of buildpacks and builders for deploying Renku frontend applications. It
+includes buildpacks for various frontend frameworks and a builder that orchestrates the build
+process.
+
+## Directory Structure
+
+*   **builders**: Contains builder definitions. A builder defines the environment and buildpacks 
+    used to build an application. For now we only maintain the selector builder.
+*   **buildpacks**: Contains individual buildpacks for different frontend frameworks. Each buildpack
+    provides the necessary scripts and configurations to detect and build applications.
+  *   **frontends**: composite buildpack for frontends.
+  *   **frontend-selector**: Buildpack for selecting the appropriate frontend.
+  *   **jupyterlab**: Buildpack for JupyterLab frontend.
+  *   **kernel-installer**: Buildpack for installing the correct kernel for the environment.
+*   **samples**: Contains sample applications for different frontend frameworks. These samples can
+    be used to test the buildpacks and builders.
+
+## Makefile Targets
+
+The `Makefile` provides several targets for building and running the project:
+
+*   **all**: Builds buildpacks, builders, and sample images.
+*   **buildpacks**: Builds all buildpacks defined in the `buildpacks` directory using `pack
+    buildpack package`.
+*   **builders**: Builds all builders defined in the `builders` directory using `pack builder
+    create`.
+*   **samples**: Builds sample images using the buildpacks and builders.  It utilizes the
+    `pack build` command with the specified builder image and environment variables.
+*   **run**: Runs a sample image with Docker, publishing port 8000.
+
+## Building the Project
+
+To build the project, run:
+
+```bash
+make
+```
+
+This will build all buildpacks, builders, and sample images.
+
+To build only the buildpacks, run:
+
+```bash
+make buildpacks
+```
+
+To build only the builders, run:
+
+```bash
+make builders
+```
+
+To build only the sample images, run:
+
+```bash
+make samples
+```
+
+Please note that the builders must be set and that you may set the `BUILDER_IMAGE` variable to
+select a builder
+
+```bash
+make samples BUILDER_IMAGE=selector
+```
+
+## Running a Sample Image
+
+To run a sample image, use the `run` target:
+
+```bash
+make run
+```
+
+You can set the `SAMPLE_IMAGE` and `FRONTEND`. For example:
+
+```bash
+make run SAMPLE_IMAGE=conda FRONTEND=jupyterlab
+```
+
+## Dependencies
+
+This project requires the following tools:
+
+*   [pack](https://buildpacks.io/docs/tools/pack/)
+*   Docker

--- a/builders/selector/builder.toml
+++ b/builders/selector/builder.toml
@@ -1,0 +1,81 @@
+description = "Ubuntu 22.04 Jammy Jellyfish full image with buildpacks for Apache HTTPD, Go, Java, Java Native Image, .NET, NGINX, Node.js, PHP, Procfile, Python, and Ruby"
+
+[[buildpacks]]
+  uri = "docker://ghcr.io/swissdatasciencecenter/vscodium-buildpack/vscodium:0.2"
+  version = "0.2.0"
+
+[[buildpacks]]
+  uri = "../../buildpacks/kernel-installer"
+  version = "0.0.1"
+
+[[buildpacks]]
+  uri = "../../buildpacks/frontend-selector"
+  version = "0.0.1"
+
+[[buildpacks]]
+  uri = "../../buildpacks/jupyterlab"
+  version = "0.0.1"
+
+[[buildpacks]]
+  uri = "../../buildpacks/frontends"
+  version = "0.0.1"
+
+[[buildpacks]]
+  uri = "docker://gcr.io/paketo-buildpacks/go:4.13.11"
+  version = "4.13.11"
+
+[[buildpacks]]
+  uri = "docker://gcr.io/paketo-buildpacks/nodejs:7.4.0"
+  version = "7.4.0"
+
+[[buildpacks]]
+  uri = "docker://gcr.io/paketo-buildpacks/python:2.24.3"
+  version = "2.24.3"
+
+[lifecycle]
+  version = "0.20.6"
+
+[[order]]
+
+  [[order.group]]
+    id = "renku/frontends"
+    version = "0.0.1"
+  [[order.group]]
+    id = "paketo-buildpacks/go"
+    version = "4.13.11"
+  [[order.group]]
+    id = "renku/kernel-installer"
+    version = "0.0.1"
+    optional = true
+
+[[order]]
+
+  [[order.group]]
+    id = "renku/frontends"
+    version = "0.0.1"
+  [[order.group]]
+    id = "paketo-buildpacks/python"
+    version = "2.24.3"
+  [[order.group]]
+    id = "renku/kernel-installer"
+    version = "0.0.1"
+    optional = true
+
+[[order]]
+
+  [[order.group]]
+    id = "renku/frontends"
+    version = "0.0.1"
+  [[order.group]]
+    id = "paketo-buildpacks/nodejs"
+    version = "7.4.0"
+  [[order.group]]
+    id = "renku/kernel-installer"
+    version = "0.0.1"
+    optional = true
+
+[stack]
+  build-image = "docker.io/paketobuildpacks/build-jammy-full:0.1.76"
+  id = "io.buildpacks.stacks.jammy"
+  run-image = "index.docker.io/paketobuildpacks/run-jammy-full:latest"
+  run-image-mirrors = []

--- a/buildpacks/frontend-selector/bin/build
+++ b/buildpacks/frontend-selector/bin/build
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+echo "=== Renku frontend buildpack ===="
+
+layers_dir=$1
+frontend_layer_dir=${layers_dir}/frontend
+launch_env_dir=${frontend_layer_dir}/env.launch
+mkdir -p ${launch_env_dir}
+
+printf "0.0.0.0" > ${launch_env_dir}/RENKU_SESSION_IP
+printf "8000" > ${launch_env_dir}/RENKU_SESSION_PORT
+printf "/workspace" > ${launch_env_dir}/RENKU_MOUNT_DIR
+printf "/workspace" > ${launch_env_dir}/RENKU_WORKING_DIR
+printf "/" > ${launch_env_dir}/RENKU_BASE_URL_PATH
+
+cat > "${frontend_layer_dir}.toml" <<EOL
+[types]
+launch = true
+EOL

--- a/buildpacks/frontend-selector/bin/build
+++ b/buildpacks/frontend-selector/bin/build
@@ -8,11 +8,11 @@ frontend_layer_dir=${layers_dir}/frontend
 launch_env_dir=${frontend_layer_dir}/env.launch
 mkdir -p ${launch_env_dir}
 
-printf "0.0.0.0" > ${launch_env_dir}/RENKU_SESSION_IP
-printf "8000" > ${launch_env_dir}/RENKU_SESSION_PORT
-printf "/workspace" > ${launch_env_dir}/RENKU_MOUNT_DIR
-printf "/workspace" > ${launch_env_dir}/RENKU_WORKING_DIR
-printf "/" > ${launch_env_dir}/RENKU_BASE_URL_PATH
+printf "0.0.0.0" > ${launch_env_dir}/RENKU_SESSION_IP.default
+printf "8000" > ${launch_env_dir}/RENKU_SESSION_PORT.default
+printf "/workspace" > ${launch_env_dir}/RENKU_MOUNT_DIR.default
+printf "/workspace" > ${launch_env_dir}/RENKU_WORKING_DIR.default
+printf "/" > ${launch_env_dir}/RENKU_BASE_URL_PATH.default
 
 cat > "${frontend_layer_dir}.toml" <<EOL
 [types]

--- a/buildpacks/frontend-selector/bin/detect
+++ b/buildpacks/frontend-selector/bin/detect
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+# 1. GET ARGS
+plan_path=$2
+
+cat >>"${plan_path}" <<EOL
+[[provides]]
+name = "frontend"
+
+[[requires]]
+name = "frontend"
+
+[requires.metadata]
+launch = true
+EOL
+
+# 2. DECLARE DEPENDENCIES (OPTIONAL)
+if [[ "${BP_REQUIRES}" == *"jupyterlab"* ]]; then
+cat >>"${plan_path}" <<EOL
+[[requires]]
+name = "jupyterlab"
+
+[requires.metadata]
+launch = true
+
+EOL
+fi
+
+if [[ "${BP_REQUIRES}" == *"vscodium"* ]]; then
+cat >>"${plan_path}" <<EOL
+[[requires]]
+name = "vscodium"
+
+[requires.metadata]
+launch = true
+
+EOL
+fi

--- a/buildpacks/frontend-selector/buildpack.toml
+++ b/buildpacks/frontend-selector/buildpack.toml
@@ -1,0 +1,17 @@
+# Buildpack API version
+api = "0.11"
+
+# Buildpack ID and metadata
+[buildpack]
+id = "renku/frontend-selector"
+version = "0.0.1"
+name = "Frontend selector buildpack"
+description = "A simple buildpack that provides a frontend."
+
+# Targets the buildpack will work with
+[[targets]]
+os = "linux"
+
+# Stacks (deprecated) the buildpack will work with
+[[stacks]]
+id = "*"

--- a/buildpacks/frontend-selector/package.toml
+++ b/buildpacks/frontend-selector/package.toml
@@ -1,0 +1,3 @@
+[buildpack]
+  uri = "."
+  

--- a/buildpacks/frontends/buildpack.toml
+++ b/buildpacks/frontends/buildpack.toml
@@ -23,6 +23,7 @@ description = "The composite buildpack that defines build orders"
     version = "0.0.1"
 
 [[order]]
+
   [[order.group]]
     id = "vscodium"
     version = "0.2.0"

--- a/buildpacks/frontends/buildpack.toml
+++ b/buildpacks/frontends/buildpack.toml
@@ -1,0 +1,33 @@
+# Buildpack API version
+api = "0.11"
+
+# Buildpack ID and metadata
+[buildpack]
+id = "renku/frontends"
+version = "0.0.1"
+name = "Frontend selector buildpack"
+description = "A simple buildpack that requires a frontend."
+
+[[order]]
+                                                     
+  [[order.group]]
+    id = "paketo-buildpacks/miniconda"
+    version = "0.10.4"                   
+
+  [[order.group]]
+    id = "renku/jupyterlab"
+    version = "0.0.1"
+
+  [[order.group]]
+    id = "renku/frontend-selector"
+    version = "0.0.1"
+
+[[order]]
+  [[order.group]]
+    id = "vscodium"
+    version = "0.2.0"
+
+  [[order.group]]
+    id = "renku/frontend-selector"
+    version = "0.0.1"
+

--- a/buildpacks/frontends/buildpack.toml
+++ b/buildpacks/frontends/buildpack.toml
@@ -5,8 +5,8 @@ api = "0.11"
 [buildpack]
 id = "renku/frontends"
 version = "0.0.1"
-name = "Frontend selector buildpack"
-description = "A simple buildpack that requires a frontend."
+name = "Frontend composite buildpack"
+description = "The composite buildpack that defines build orders"
 
 [[order]]
                                                      

--- a/buildpacks/frontends/package.toml
+++ b/buildpacks/frontends/package.toml
@@ -1,0 +1,14 @@
+[buildpack]
+  uri = "."
+
+[[dependencies]]
+  uri = "../frontend-selector"
+
+[[dependencies]]
+  uri = "../jupyterlab"
+
+[[dependencies]]
+  uri = "docker://ghcr.io/swissdatasciencecenter/vscodium-buildpack/vscodium:0.2"
+
+[[dependencies]]
+  uri = "urn:cnb:registry:paketo-buildpacks/miniconda@0.10.4"

--- a/buildpacks/jupyterlab/bin/build
+++ b/buildpacks/jupyterlab/bin/build
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+echo "=== Renku Jupyterlab buildpack ===="
+
+layers_dir=$1
+cache_layer_dir=${layers_dir}/cache
+jupyter_layer_dir=${layers_dir}/jupyterlab
+launch_env_dir=${jupyter_layer_dir}/env.launch
+mkdir -p ${cache_layer_dir}
+mkdir -p ${launch_env_dir}
+
+conda config --add pkgs_dirs ${cache_layer_dir}
+conda create -c conda-forge -y -p ${jupyter_layer_dir} jupyterlab
+. $(dirname $(dirname $(which conda)))/etc/profile.d/conda.sh
+conda activate ${jupyter_layer_dir}
+jupyter kernelspec remove -f python3
+conda deactivate
+
+printf "0.0.0.0" > ${launch_env_dir}/RENKU_SESSION_IP
+printf "8000" > ${launch_env_dir}/RENKU_SESSION_PORT
+printf "/workspace" > ${launch_env_dir}/RENKU_MOUNT_DIR
+printf "/workspace" > ${launch_env_dir}/RENKU_WORKING_DIR
+printf "/" > ${launch_env_dir}/RENKU_BASE_URL_PATH
+
+cat >${jupyter_layer_dir}/bin/jupyterlab-entrypoint.sh<<EOL
+#!/usr/bin/env bash
+${jupyter_layer_dir}/bin/python -E ${jupyter_layer_dir}/bin/jupyter-lab \
+        --ip \${RENKU_SESSION_IP} \
+        --port \${RENKU_SESSION_PORT} \
+        --ServerApp.base_url \$RENKU_BASE_URL_PATH \
+        --ServerApp.token "" \
+        --ServerApp.password "" \
+        --ServerApp.allow_remote_access true \
+        --ContentsManager.allow_hidden true \
+        --ServerApp.root_dir \${RENKU_WORKING_DIR} \
+        --KernelSpecManager.ensure_native_kernel False
+EOL
+chmod ug+x ${jupyter_layer_dir}/bin/jupyterlab-entrypoint.sh
+
+# Write layer metadata (CNB requirement)
+cat >"${layers_dir}/jupyterlab.toml" <<EOL
+[types]
+launch = true
+
+[metadata]
+description = "jupyterlab frontend for renku"
+version = "0.0.1"
+EOL
+
+# 4. SET DEFAULT START COMMAND
+cat > "${layers_dir}/launch.toml" << EOL
+[[processes]]
+type = "jupyterlab"
+command = "${jupyter_layer_dir}/bin/jupyterlab-entrypoint.sh"
+args = []
+default = true
+direct = false
+EOL

--- a/buildpacks/jupyterlab/bin/build
+++ b/buildpacks/jupyterlab/bin/build
@@ -52,8 +52,7 @@ EOL
 cat > "${layers_dir}/launch.toml" << EOL
 [[processes]]
 type = "jupyterlab"
-command = "${jupyter_layer_dir}/bin/jupyterlab-entrypoint.sh"
+command = ["${jupyter_layer_dir}/bin/jupyterlab-entrypoint.sh"]
 args = []
 default = true
-direct = false
 EOL

--- a/buildpacks/jupyterlab/bin/build
+++ b/buildpacks/jupyterlab/bin/build
@@ -17,11 +17,11 @@ conda activate ${jupyter_layer_dir}
 jupyter kernelspec remove -f python3
 conda deactivate
 
-printf "0.0.0.0" > ${launch_env_dir}/RENKU_SESSION_IP
-printf "8000" > ${launch_env_dir}/RENKU_SESSION_PORT
-printf "/workspace" > ${launch_env_dir}/RENKU_MOUNT_DIR
-printf "/workspace" > ${launch_env_dir}/RENKU_WORKING_DIR
-printf "/" > ${launch_env_dir}/RENKU_BASE_URL_PATH
+printf "0.0.0.0" > ${launch_env_dir}/RENKU_SESSION_IP.default
+printf "8000" > ${launch_env_dir}/RENKU_SESSION_PORT.default
+printf "/workspace" > ${launch_env_dir}/RENKU_MOUNT_DIR.default
+printf "/workspace" > ${launch_env_dir}/RENKU_WORKING_DIR.default
+printf "/" > ${launch_env_dir}/RENKU_BASE_URL_PATH.default
 
 cat >${jupyter_layer_dir}/bin/jupyterlab-entrypoint.sh<<EOL
 #!/usr/bin/env bash

--- a/buildpacks/jupyterlab/bin/detect
+++ b/buildpacks/jupyterlab/bin/detect
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+cat > "${CNB_BUILD_PLAN_PATH}" << EOL
+[[requires]]
+  name = "conda"
+
+[requires.metadata]
+  build = true
+
+[[provides]]
+  name = "jupyterlab"
+
+[[requires]]
+  name = "jupyterlab"
+
+[requires.metadata]
+  launch = true
+EOL

--- a/buildpacks/jupyterlab/buildpack.toml
+++ b/buildpacks/jupyterlab/buildpack.toml
@@ -1,0 +1,10 @@
+api = "0.8"
+
+[buildpack]
+id = "renku/jupyterlab"
+name = "Jupyterlab frontend Buildpack"
+version = "0.0.1"
+
+[[targets]]
+  os = "linux"
+  arch = "amd64"

--- a/buildpacks/jupyterlab/buildpack.toml
+++ b/buildpacks/jupyterlab/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.8"
+api = "0.11"
 
 [buildpack]
 id = "renku/jupyterlab"

--- a/buildpacks/jupyterlab/package.toml
+++ b/buildpacks/jupyterlab/package.toml
@@ -1,0 +1,2 @@
+[buildpack]
+  uri = "."

--- a/buildpacks/kernel-installer/bin/build
+++ b/buildpacks/kernel-installer/bin/build
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+echo "=== Renku kernel installer buildpack ===="
+
+env
+
+layers_dir=$1
+cache_layer_dir=${layers_dir}/cache
+kernel_layer_dir=${layers_dir}/kernel
+env_dir=${kernel_layer_dir}/env
+mkdir -p ${cache_layer_dir}
+mkdir -p ${env_dir}
+
+python -m pip install --prefix=${kernel_layer_dir} --cache-dir=${cache_layer_dir} ipykernel
+site_packages=$(find $kernel_layer_dir/lib -type d -name site-packages)
+export PYTHONPATH=$site_packages:$PYTHONPATH
+export JUPYTER_PATH=${kernel_layer_dir}/share/jupyter/
+python -m ipykernel install --prefix=${kernel_layer_dir} --name=custom_env
+${kernel_layer_dir}/bin/jupyter-kernelspec remove -f python3
+
+printf "${JUPYTER_PATH}"> ${env_dir}/JUPYTER_PATH
+printf ':'> ${env_dir}/PYTHONPATH.delim
+printf "${site_packages}"> ${env_dir}/PYTHONPATH.prepend
+
+cat > "${cache_layer_dir}.toml" <<EOL
+[types]
+cache = true
+EOL
+
+cat > "${kernel_layer_dir}.toml" <<EOL
+[types]
+cache = true
+launch = true
+EOL
+

--- a/buildpacks/kernel-installer/bin/build
+++ b/buildpacks/kernel-installer/bin/build
@@ -13,7 +13,8 @@ mkdir -p ${cache_layer_dir}
 mkdir -p ${env_dir}
 
 python -m pip install --prefix=${kernel_layer_dir} --cache-dir=${cache_layer_dir} ipykernel
-site_packages=$(find $kernel_layer_dir/lib -type d -name site-packages)
+python_version=python$(python --version|cut -d' ' -f2)
+site_packages=$kernel_layer_dir/lib/${python_version%.*}/site-packages
 export PYTHONPATH=$site_packages:$PYTHONPATH
 export JUPYTER_PATH=${kernel_layer_dir}/share/jupyter/
 python -m ipykernel install --prefix=${kernel_layer_dir} --name=custom_env

--- a/buildpacks/kernel-installer/bin/detect
+++ b/buildpacks/kernel-installer/bin/detect
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+# 1. GET ARGS
+plan_path=$2
+
+# 2. DECLARE DEPENDENCIES (OPTIONAL)
+
+cat >>"${plan_path}" <<EOL
+[[requires]]
+name = "jupyterlab"
+
+[requires.metadata]
+launch = true
+
+[[requires]]
+name = "pip"
+
+[requires.metadata]
+build = true
+
+[[requires]]
+name = "site-packages"
+
+[requires.metadata]
+build = true
+launch = true
+
+[[or]]
+[[or.requires]]
+name = "conda-environment"
+
+[or.requires.metadata]
+build = true
+launch = true
+EOL
+

--- a/buildpacks/kernel-installer/bin/detect
+++ b/buildpacks/kernel-installer/bin/detect
@@ -28,6 +28,12 @@ launch = true
 
 [[or]]
 [[or.requires]]
+name = "jupyterlab"
+
+[or.requires.metadata]
+launch = true
+
+[[or.requires]]
 name = "conda-environment"
 
 [or.requires.metadata]

--- a/buildpacks/kernel-installer/buildpack.toml
+++ b/buildpacks/kernel-installer/buildpack.toml
@@ -1,0 +1,16 @@
+# Buildpack API version
+api = "0.11"
+
+# Buildpack ID and metadata
+[buildpack]
+id = "renku/kernel-installer"
+version = "0.0.1"
+name = "jupyter kernel installer"
+
+# Targets the buildpack will work with
+[[targets]]
+os = "linux"
+
+# Stacks (deprecated) the buildpack will work with
+[[stacks]]
+id = "*"

--- a/buildpacks/kernel-installer/package.toml
+++ b/buildpacks/kernel-installer/package.toml
@@ -1,0 +1,2 @@
+[buildpack]
+  uri = "."

--- a/samples/conda/cowsay-version.ipynb
+++ b/samples/conda/cowsay-version.ipynb
@@ -1,0 +1,39 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d4506b1d-8a55-4331-9057-13936476b22d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from cowpy import cow\n",
+    "import sys\n",
+    "\n",
+    "mycow = cow.Cowacter()\n",
+    "print(mycow.milk(sys.version))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "custom_env",
+   "language": "python",
+   "name": "custom_env"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.16"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/samples/conda/environment.yml
+++ b/samples/conda/environment.yml
@@ -1,0 +1,6 @@
+name: mycowsay
+channels:
+  - conda-forge
+dependencies:
+  - python >=3.10, <3.11
+  - cowpy

--- a/samples/pip/cowsay-version.ipynb
+++ b/samples/pip/cowsay-version.ipynb
@@ -1,0 +1,38 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": "",
+   "id": "d4506b1d-8a55-4331-9057-13936476b22d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import cowsay\n",
+    "import sys\n",
+    "\n",
+    "print(cowsay.cowsay(sys.version, width=80))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "custom_env",
+   "language": "python",
+   "name": "custom_env"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.16"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/samples/pip/requirements.txt
+++ b/samples/pip/requirements.txt
@@ -1,0 +1,1 @@
+python-cowsay


### PR DESCRIPTION
## Overview
This PR implements a configurable frontend selection system for Renku using Cloud Native Buildpacks, with primary support for JupyterLab. The implementation follows the CNB architecture and introduces a new builder configuration that enables dynamic frontend selection during container builds.

## Changes

### Builder Configuration
- Added a new ```selector``` builder with complete configuration in ```builder.toml```
- Configured build and run images using Paketo's Ubuntu 22.04 Jammy stack
- Set up buildpack order to properly handle frontend selection


### New Buildpacks
1. **Frontend Selector Buildpack**
   - Implements detection logic to determine required frontends
   - Supports environment variable configuration via ```BP_REQUIRES```
   - Handles dependencies for JupyterLab and VSCodium

2. **JupyterLab Buildpack** 
   - Provides JupyterLab as a frontend option
   - Sets up proper launch configuration
   - Depends on Conda for Python environment

3. **Kernel Installer Buildpack**
   - Configures Python kernels for Jupyter (pip and conda)
   - Sets up necessary environment variables
   - Manages caching for efficient builds
