### PR TITLE
feat: Introduce Renku Extension for Buildpacks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ SAMPLE_IMAGES := $(shell find samples -maxdepth 1 -type d -not -path "samples" -
 # Buildpacks directory (assuming each subdirectory contains a buildpack)
 BUILDPACKS := $(shell find buildpacks -maxdepth 1 -type d -not -path "buildpacks" -printf "%P ")
 
+# Buildpacks directory (assuming each subdirectory contains a buildpack)
+EXTENSIONS := $(shell find extensions -maxdepth 1 -type d -not -path "extensions" -printf "%P ")
+
 # Builders directory (assuming each subdirectory contains a builder definition)
 BUILDERS := $(shell find builders -maxdepth 1 -type d -not -path "builders" -printf "%P ")
 
@@ -21,15 +24,22 @@ FRONTEND ?= $(word 1, $(FRONTENDS))
 
 SAMPLE_IMAGE ?= $(word 1, $(SAMPLE_IMAGES))
 
-.PHONY: all buildpacks builders samples clean
+.PHONY: all buildpacks extensions builders samples
 
-all: buildpacks builders samples
+all: buildpacks extensions builders samples
 
 buildpacks:
 	@echo "Building buildpacks..."
 	@for bp in $(BUILDPACKS); do \
 		echo "  Building buildpack: $$bp"; \
 		pack buildpack package $$bp --config buildpacks/$$bp/package.toml --target "linux/amd64"; \
+	done
+
+extensions:
+	@echo "Building extensions..."
+	@for extension in $(EXTENSIONS); do \
+		echo "  Building extension: $$extension"; \
+		pack extension package $$extension --config extensions/$$extension/package.toml; \
 	done
 
 builders:

--- a/builders/selector/builder.toml
+++ b/builders/selector/builder.toml
@@ -80,9 +80,10 @@ description = "Ubuntu 22.04 Jammy Jellyfish full image with buildpacks for Apach
     optional = true
 
 [[order-extensions]]
-[[order-extensions.group]]
-  id = "renku/renku"
-  version = "0.0.1"
+
+  [[order-extensions.group]]
+    id = "renku/renku"
+    version = "0.0.1"
 
 [stack]
   build-image = "docker.io/paketobuildpacks/build-jammy-full:0.1.76"

--- a/builders/selector/builder.toml
+++ b/builders/selector/builder.toml
@@ -32,6 +32,11 @@ description = "Ubuntu 22.04 Jammy Jellyfish full image with buildpacks for Apach
   uri = "docker://gcr.io/paketo-buildpacks/python:2.24.3"
   version = "2.24.3"
 
+[[extensions]]
+  id = "renku/renku"
+  version = "0.0.1"
+  uri = "../../extensions/renku"
+
 [lifecycle]
   version = "0.20.6"
 
@@ -73,6 +78,11 @@ description = "Ubuntu 22.04 Jammy Jellyfish full image with buildpacks for Apach
     id = "renku/kernel-installer"
     version = "0.0.1"
     optional = true
+
+[[order-extensions]]
+[[order-extensions.group]]
+  id = "renku/renku"
+  version = "0.0.1"
 
 [stack]
   build-image = "docker.io/paketobuildpacks/build-jammy-full:0.1.76"

--- a/buildpacks/frontend-selector/bin/detect
+++ b/buildpacks/frontend-selector/bin/detect
@@ -13,6 +13,13 @@ name = "frontend"
 
 [requires.metadata]
 launch = true
+
+[[requires]]
+name = "renku-extensions"
+
+[requires.metadata]
+launch = true
+
 EOL
 
 # 2. DECLARE DEPENDENCIES (OPTIONAL)

--- a/buildpacks/jupyterlab/bin/build
+++ b/buildpacks/jupyterlab/bin/build
@@ -11,9 +11,25 @@ mkdir -p ${cache_layer_dir}
 mkdir -p ${launch_env_dir}
 
 conda config --add pkgs_dirs ${cache_layer_dir}
-conda create -c conda-forge -y -p ${jupyter_layer_dir} jupyterlab
+conda create -c conda-forge -y -p ${jupyter_layer_dir} \
+  "jupyterlab>4.0,<5.0" \
+  "jupyter-server-proxy==4.3.0" \
+  "bleach>5.0.0" \
+  "certifi>=2022.12.7" \
+  "Jinja2<3.1" \
+  "jupyterlab-git==0.50.1" \
+  "jupyter_server==2.6.0" \
+  "mistune>=2.0.1" \
+  "papermill~=2.6.0" \
+  "requests>=2.20.0" \
+  "setuptools>=65.5.1" \
+  "virtualenv>=20.7.2" \
+  "ipython>=8.10.0" \
+  "tornado>=6.3.3" \
+  "packaging>=22.0"
 . $(dirname $(dirname $(which conda)))/etc/profile.d/conda.sh
 conda activate ${jupyter_layer_dir}
+pip install backports.tarfile # beacuse of https://github.com/SwissDataScienceCenter/renkulab-docker/issues/471
 jupyter kernelspec remove -f python3
 conda deactivate
 
@@ -25,11 +41,11 @@ printf "/" > ${launch_env_dir}/RENKU_BASE_URL_PATH.default
 
 cat >${jupyter_layer_dir}/bin/jupyterlab-entrypoint.sh<<EOL
 #!/usr/bin/env bash
-${jupyter_layer_dir}/bin/python -E ${jupyter_layer_dir}/bin/jupyter-lab \
+SHELL=/bin/bash ${jupyter_layer_dir}/bin/python -E ${jupyter_layer_dir}/bin/jupyter-lab \
         --ip \${RENKU_SESSION_IP} \
         --port \${RENKU_SESSION_PORT} \
         --ServerApp.base_url \$RENKU_BASE_URL_PATH \
-        --ServerApp.token "" \
+        --IdentityProvider.token "" \
         --ServerApp.password "" \
         --ServerApp.allow_remote_access true \
         --ContentsManager.allow_hidden true \

--- a/buildpacks/jupyterlab/bin/build
+++ b/buildpacks/jupyterlab/bin/build
@@ -12,7 +12,7 @@ mkdir -p ${launch_env_dir}
 
 conda config --add pkgs_dirs ${cache_layer_dir}
 conda create -c conda-forge -y -p ${jupyter_layer_dir} \
-  "jupyterlab>4.0,<5.0" \
+  "jupyterlab>=4.4,<4.5" \
   "jupyter-server-proxy==4.3.0" \
   "bleach>5.0.0" \
   "certifi>=2022.12.7" \

--- a/extensions/renku/bin/detect
+++ b/extensions/renku/bin/detect
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+# 1. GET ARGS
+plan_path=$CNB_BUILD_PLAN_PATH
+
+echo Extension Plan Path : ${plan_path}
+
+# 2. DECLARE DEPENDENCIES (OPTIONAL)
+cat >> "${plan_path}" <<EOL
+# Extension provides this dependency
+[[provides]]
+name = "renku-extensions"
+EOL

--- a/extensions/renku/bin/generate
+++ b/extensions/renku/bin/generate
@@ -60,7 +60,6 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
     libyaml-0-2 \
     libyaml-dev \
     lmodern \
-    musl-dev \
     nano \
     netcat-traditional \
     rclone \
@@ -68,7 +67,6 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
     vim && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
-    ln -s /usr/lib/x86_64-linux-musl/libc.so /lib/libc.musl-x86_64.so.1 && \
     wget -q https://github.com/git-lfs/git-lfs/releases/download/v3.3.0/git-lfs-linux-"\$(dpkg --print-architecture)"-v3.3.0.tar.gz -P /tmp && \
     wget -q  https://github.com/justjanne/powerline-go/releases/download/v1.24/powerline-go-linux-"\$(dpkg --print-architecture)" -O /usr/local/bin/powerline-shell && \
     chmod a+x /usr/local/bin/powerline-shell && \

--- a/extensions/renku/bin/generate
+++ b/extensions/renku/bin/generate
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+# 1. GET ARGS
+output_dir=$CNB_OUTPUT_DIR
+
+context_dir=${output_dir}/context
+mkdir -p ${context_dir}
+cat >>"${context_dir}/.bashrc" <<EOL
+# Setup git user
+if [[ -z "\$(git config --global --get user.name)" && -v GIT_AUTHOR_NAME ]]; then
+    git config --global user.name "\$GIT_AUTHOR_NAME"
+fi
+if [[ -z "\$(git config --global --get user.email)" && -v EMAIL ]]; then
+    git config --global user.email "\$EMAIL"
+fi
+
+function _update_ps1() {
+    PS1="\$(/usr/local/bin/powerline-shell -error \$? -jobs \$(jobs -p | wc -l) -mode compatible -modules ssh,venv,cwd,git,root)"
+}
+
+if [ "\$TERM" != "linux" ] && [ -f "/usr/local/bin/powerline-shell" ]; then
+    PROMPT_COMMAND="_update_ps1; \$PROMPT_COMMAND"
+fi
+
+export RENKU_DISABLE_VERSION_CHECK=1
+EOL
+
+
+# 2. GENERATE run.Dockerfile
+cat >>"${output_dir}/run.Dockerfile" <<EOL
+ARG base_image
+FROM \${base_image}
+
+ARG user_id
+ARG group_id
+ARG build_id=0
+
+LABEL maintainer="Swiss Data Science Center <info@datascience.ch>"
+LABEL io.buildpacks.rebasable=false
+
+USER root
+
+RUN usermod -s /bin/bash \$(id -nu \$(user_id))
+
+SHELL [ "/bin/bash", "-c", "-o", "pipefail" ]
+
+# Install additional dependencies and nice-to-have packages
+RUN apt-get update && apt-get install -yq --no-install-recommends \
+    build-essential \
+    curl \
+    git \
+    gnupg \
+    graphviz \
+    jq \
+    less \
+    libsm6 \
+    libxext-dev \
+    libxrender1 \
+    libyaml-0-2 \
+    libyaml-dev \
+    lmodern \
+    musl-dev \
+    nano \
+    netcat-traditional \
+    rclone \
+    unzip \
+    vim && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    ln -s /usr/lib/x86_64-linux-musl/libc.so /lib/libc.musl-x86_64.so.1 && \
+    wget -q https://github.com/git-lfs/git-lfs/releases/download/v3.3.0/git-lfs-linux-"\$(dpkg --print-architecture)"-v3.3.0.tar.gz -P /tmp && \
+    wget -q  https://github.com/justjanne/powerline-go/releases/download/v1.24/powerline-go-linux-"\$(dpkg --print-architecture)" -O /usr/local/bin/powerline-shell && \
+    chmod a+x /usr/local/bin/powerline-shell && \
+    tar -zxvf /tmp/git-lfs-linux-"\$(dpkg --print-architecture)"-v3.3.0.tar.gz -C /tmp && \
+    /tmp/git-lfs-3.3.0/install.sh && \
+    rm -rf /tmp/git-lfs*
+
+RUN echo \$build_id
+
+USER \$user_id
+
+COPY .bashrc /etc/skel
+RUN cp /etc/skel/.bashrc \$HOME/
+
+EOL
+

--- a/extensions/renku/extension.toml
+++ b/extensions/renku/extension.toml
@@ -1,0 +1,9 @@
+# Buildpack API version
+api = "0.10"
+
+# Extension ID and metadata
+[extension]
+id = "renku/renku"
+version = "0.0.1"
+name = "Renku Extension"
+description = "A simple extension that enables Renku additions to a base debian image"

--- a/extensions/renku/package.toml
+++ b/extensions/renku/package.toml
@@ -1,0 +1,2 @@
+[extension]
+  uri = "."


### PR DESCRIPTION
This pull request introduces a new extension that enhances the base Debian image with Renku-specific additions.

Key changes:

*   **extensions/renku**: Added the Renku extension, which includes scripts and configurations for Renku projects.
*   **Makefile**: Added support for building extensions.
*   **builders/selector**: Configured the builder to include the Renku extension.
*   **buildpacks/frontend-selector**: Modified the frontend selector buildpack to require the Renku extension.
*   **buildpacks/jupyterlab**: Updated jupyterlab buildpack to install patched dependencies of jupyterlab to mitigate security vulnerabilities and other breaking changes (from https://github.com/SwissDataScienceCenter/renkulab-docker/blob/main/docker/py/environment.yml)

This extension adds essential tools and configurations required for Renku projects.