### PR TITLE
fix: isolate jupyterlab env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ samples:
 	@echo "Building sample images..."
 	@for image in $(SAMPLE_IMAGES); do \
 		echo "  Building image: $$image with $(BUILDER_IMAGE)"; \
-		pack build $$image-$(FRONTEND) --path samples/$$image --env BP_REQUIRES=$(FRONTEND) --builder $(BUILDER_IMAGE) --platform "linux"; \
+		pack build $$image-$(FRONTEND) --clear-cache --path samples/$$image --env BP_REQUIRES=$(FRONTEND) --builder $(BUILDER_IMAGE) --platform "linux"; \
 	done
 
 run:

--- a/buildpacks/jupyterlab/bin/build
+++ b/buildpacks/jupyterlab/bin/build
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-echo "=== Renku Jupyterlab buildpack ===="
+echo "=== Renku Jupyterlab buildpack ==="
 
 layers_dir=$1
 cache_layer_dir=${layers_dir}/cache
-jupyter_layer_dir=${layers_dir}/jupyterlab
+jupyter_layer_dir=${layers_dir}/jupyterlab/env
 launch_env_dir=${jupyter_layer_dir}/env.launch
 mkdir -p ${cache_layer_dir}
 mkdir -p ${launch_env_dir}
@@ -34,11 +34,11 @@ pip install backports.tarfile # beacuse of https://github.com/SwissDataScienceCe
 jupyter kernelspec remove -f python3
 conda deactivate
 
-printf "0.0.0.0" > ${launch_env_dir}/RENKU_SESSION_IP.default
-printf "8000" > ${launch_env_dir}/RENKU_SESSION_PORT.default
-printf "/workspace" > ${launch_env_dir}/RENKU_MOUNT_DIR.default
-printf "/workspace" > ${launch_env_dir}/RENKU_WORKING_DIR.default
-printf "/" > ${launch_env_dir}/RENKU_BASE_URL_PATH.default
+printf "0.0.0.0" >${launch_env_dir}/RENKU_SESSION_IP.default
+printf "8000" >${launch_env_dir}/RENKU_SESSION_PORT.default
+printf "/workspace" >${launch_env_dir}/RENKU_MOUNT_DIR.default
+printf "/workspace" >${launch_env_dir}/RENKU_WORKING_DIR.default
+printf "/" >${launch_env_dir}/RENKU_BASE_URL_PATH.default
 
 cat >${jupyter_layer_dir}/bin/jupyterlab-entrypoint.sh<<EOL
 #!/usr/bin/env bash
@@ -66,7 +66,7 @@ version = "0.0.1"
 EOL
 
 # 4. SET DEFAULT START COMMAND
-cat > "${layers_dir}/launch.toml" << EOL
+cat >"${layers_dir}/launch.toml" << EOL
 [[processes]]
 type = "jupyterlab"
 command = ["${jupyter_layer_dir}/bin/jupyterlab-entrypoint.sh"]

--- a/buildpacks/jupyterlab/bin/build
+++ b/buildpacks/jupyterlab/bin/build
@@ -5,14 +5,17 @@ echo "=== Renku Jupyterlab buildpack ==="
 
 layers_dir=$1
 cache_layer_dir=${layers_dir}/cache
-jupyter_layer_dir=${layers_dir}/jupyterlab/env
+jupyter_layer_dir=${layers_dir}/jupyterlab
+jupyter_environment_dir=${layers_dir}/jupyterlab/jupyterlab_env
 launch_env_dir=${jupyter_layer_dir}/env.launch
+mkdir -p ${jupyter_environment_dir}
+mkdir -p ${jupyter_layer_dir}/bin
 mkdir -p ${cache_layer_dir}
 mkdir -p ${launch_env_dir}
 
 conda config --remove channels defaults
 conda config --add pkgs_dirs ${cache_layer_dir}
-conda create -c conda-forge -c nodefaults -y -p ${jupyter_layer_dir} \
+conda create -c conda-forge -c nodefaults -y -p ${jupyter_environment_dir} \
   "jupyterlab>=4.4,<4.5" \
   "jupyter-server-proxy==4.3.0" \
   "bleach>5.0.0" \
@@ -29,7 +32,7 @@ conda create -c conda-forge -c nodefaults -y -p ${jupyter_layer_dir} \
   "tornado>=6.3.3" \
   "packaging>=22.0"
 . $(dirname $(dirname $(which conda)))/etc/profile.d/conda.sh
-conda activate ${jupyter_layer_dir}
+conda activate ${jupyter_environment_dir}
 pip install backports.tarfile # beacuse of https://github.com/SwissDataScienceCenter/renkulab-docker/issues/471
 jupyter kernelspec remove -f python3
 conda deactivate
@@ -42,7 +45,7 @@ printf "/" >${launch_env_dir}/RENKU_BASE_URL_PATH.default
 
 cat >${jupyter_layer_dir}/bin/jupyterlab-entrypoint.sh<<EOL
 #!/usr/bin/env bash
-SHELL=/bin/bash ${jupyter_layer_dir}/bin/python -E ${jupyter_layer_dir}/bin/jupyter-lab \
+SHELL=/bin/bash ${jupyter_environment_dir}/bin/python -E ${jupyter_environment_dir}/bin/jupyter-lab \
         --ip \${RENKU_SESSION_IP} \
         --port \${RENKU_SESSION_PORT} \
         --ServerApp.base_url \$RENKU_BASE_URL_PATH \
@@ -69,7 +72,7 @@ EOL
 cat >"${layers_dir}/launch.toml" << EOL
 [[processes]]
 type = "jupyterlab"
-command = ["${jupyter_layer_dir}/bin/jupyterlab-entrypoint.sh"]
+command = ["jupyterlab-entrypoint.sh"]
 args = []
 default = true
 EOL


### PR DESCRIPTION
**Purpose:**

This pull request isolates the JupyterLab environment within its own directory to prevent conflicts with other buildpacks. Additionally, it fixes minor formatting issues in the build script.

**Key Changes:**

*   Isolates the JupyterLab environment by moving it to `jupyterlab/env`.
*   Corrects minor formatting inconsistencies in the build script (e.g., spacing in echo statements, quotes in file creation).

**Review Focus:**

*   Please ensure that the changes to the `jupyterlab-entrypoint.sh` path are correct and that the JupyterLab environment is properly activated.
*   Verify that the environment isolation does not introduce any regressions or break existing functionality.

**Related Issues/PRs:**

*   Alternative to #12 
*   fixes #10