### PR TITLE
feat: add run image build step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ FRONTEND ?= $(word 1, $(FRONTENDS))
 
 SAMPLE_IMAGE ?= $(word 1, $(SAMPLE_IMAGES))
 
-.PHONY: all buildpacks extensions builders samples
+.PHONY: all buildpacks extensions builders samples run_image
 
 all: buildpacks extensions builders samples
 
@@ -59,3 +59,7 @@ samples:
 run:
 	@echo "Running sample image : $(SAMPLE_IMAGE)-$(FRONTEND)"
 	docker run -it --rm --publish 8000:8000 --entrypoint $(FRONTEND) $(SAMPLE_IMAGE)-$(FRONTEND):latest
+
+run_image:
+	# TODO: Upgrade to properly tag based on commit/tag
+	docker build -t ghcr.io/swissdatasciencecenter/renku-frontend-buildpacks/base-image:0.0.1 -f ./extensions/renku/generate/run.Dockerfile ./extensions/renku/generate/context/

--- a/extensions/renku/generate/run.Dockerfile
+++ b/extensions/renku/generate/run.Dockerfile
@@ -1,8 +1,8 @@
-ARG base_image
+ARG base_image=index.docker.io/paketobuildpacks/run-jammy-full:latest
 FROM ${base_image}
 
-ARG user_id
-ARG group_id
+ARG user_id=1000
+ARG group_id=1000
 ARG build_id=0
 
 LABEL maintainer="Swiss Data Science Center <info@datascience.ch>"
@@ -41,7 +41,9 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
     chmod a+x /usr/local/bin/powerline-shell && \
     tar -zxvf /tmp/git-lfs-linux-"$(dpkg --print-architecture)"-v3.3.0.tar.gz -C /tmp && \
     /tmp/git-lfs-3.3.0/install.sh && \
-    rm -rf /tmp/git-lfs*
+    rm -rf /tmp/git-lfs* && \
+    groupadd -f --gid ${group_id} renku && \
+    useradd --gid ${group_id} --uid ${user_id} --create-home renku
 
 RUN echo $build_id
 


### PR DESCRIPTION
We can fully automate and streamline the publishing in followup PRs.

I just wanted to have a way and trace of how we got our base run image.

