### PR TITLE
chore: bump versions to 0.0.2

### DIFF
--- a/builders/selector/builder.toml
+++ b/builders/selector/builder.toml
@@ -7,15 +7,15 @@ description = "Ubuntu 22.04 Jammy Jellyfish full image with buildpacks for Apach
 
 [[buildpacks]]
   uri = "../../buildpacks/kernel-installer"
-  version = "0.0.1"
+  version = "0.0.2"
 
 [[buildpacks]]
   uri = "../../buildpacks/jupyterlab"
-  version = "0.0.1"
+  version = "0.0.2"
 
 [[buildpacks]]
   uri = "../../buildpacks/python-dependency-manager"
-  version = "0.0.1"
+  version = "0.0.2"
 
 [[buildpacks]]
   uri = "docker://gcr.io/paketo-buildpacks/python:2.24.3"
@@ -39,13 +39,13 @@ description = "Ubuntu 22.04 Jammy Jellyfish full image with buildpacks for Apach
     version = "2.24.3"
   [[order.group]]
     id = "renku/python-dependency-manager"
-    version = "0.0.1"
+    version = "0.0.2"
   [[order.group]]
     id = "renku/jupyterlab"
-    version = "0.0.1"
+    version = "0.0.2"
   [[order.group]]
     id = "renku/kernel-installer"
-    version = "0.0.1"
+    version = "0.0.2"
 
 [[order]]
 
@@ -54,7 +54,7 @@ description = "Ubuntu 22.04 Jammy Jellyfish full image with buildpacks for Apach
     version = "2.24.3"
   [[order.group]]
     id = "renku/python-dependency-manager"
-    version = "0.0.1"
+    version = "0.0.2"
   [[order.group]]
     id = "vscodium"
     version = "0.3.0"
@@ -62,5 +62,5 @@ description = "Ubuntu 22.04 Jammy Jellyfish full image with buildpacks for Apach
 [stack]
   build-image = "docker.io/paketobuildpacks/builder-jammy-buildpackless-full:0.0.256"
   id = "io.buildpacks.stacks.jammy"
-  run-image = "ghcr.io/swissdatasciencecenter/renku-frontend-buildpacks/base-image:0.0.1"
+  run-image = "ghcr.io/swissdatasciencecenter/renku-frontend-buildpacks/base-image:0.0.2"
   run-image-mirrors = []

--- a/buildpacks/jupyterlab/bin/build
+++ b/buildpacks/jupyterlab/bin/build
@@ -24,13 +24,13 @@ jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
 conda deactivate
 
 mkdir -p "${launch_env_dir}"
-printf "0.0.0.0" > "${launch_env_dir}/RENKU_SESSION_IP.default"
-printf "8000" > "${launch_env_dir}/RENKU_SESSION_PORT.default"
-printf "/workspace" > "${launch_env_dir}/RENKU_MOUNT_DIR.default"
-printf "/workspace" > "${launch_env_dir}/RENKU_WORKING_DIR.default"
-printf "/" > "${launch_env_dir}/RENKU_BASE_URL_PATH.default"
+printf "0.0.0.0" >"${launch_env_dir}/RENKU_SESSION_IP.default"
+printf "8000" >"${launch_env_dir}/RENKU_SESSION_PORT.default"
+printf "/workspace" >"${launch_env_dir}/RENKU_MOUNT_DIR.default"
+printf "/workspace" >"${launch_env_dir}/RENKU_WORKING_DIR.default"
+printf "/" >"${launch_env_dir}/RENKU_BASE_URL_PATH.default"
 
-cat >"${jupyter_layer_dir}"/bin/jupyterlab-entrypoint.sh<<EOL
+cat >"${jupyter_layer_dir}"/bin/jupyterlab-entrypoint.sh <<EOL
 #!/usr/bin/env bash
 SHELL=/bin/bash "${jupyter_environment_dir}/bin/python" -E "${jupyter_environment_dir}/bin/jupyter-lab" \
         --ip "\${RENKU_SESSION_IP}" \
@@ -52,11 +52,11 @@ launch = true
 
 [metadata]
 description = "jupyterlab frontend for renku"
-version = "0.0.1"
+version = "0.0.2"
 EOL
 
 # 4. SET DEFAULT START COMMAND
-cat >"${layers_dir}/launch.toml" << EOL
+cat >"${layers_dir}/launch.toml" <<EOL
 [[processes]]
 type = "jupyterlab"
 command = ["jupyterlab-entrypoint.sh"]

--- a/buildpacks/jupyterlab/buildpack.toml
+++ b/buildpacks/jupyterlab/buildpack.toml
@@ -3,7 +3,7 @@ api = "0.11"
 [buildpack]
 id = "renku/jupyterlab"
 name = "Jupyterlab frontend Buildpack"
-version = "0.0.1"
+version = "0.0.2"
 
 [[targets]]
   os = "linux"

--- a/buildpacks/kernel-installer/buildpack.toml
+++ b/buildpacks/kernel-installer/buildpack.toml
@@ -4,7 +4,7 @@ api = "0.11"
 # Buildpack ID and metadata
 [buildpack]
 id = "renku/kernel-installer"
-version = "0.0.1"
+version = "0.0.2"
 name = "jupyter kernel installer"
 
 # Targets the buildpack will work with

--- a/buildpacks/python-dependency-manager/bin/build
+++ b/buildpacks/python-dependency-manager/bin/build
@@ -24,5 +24,5 @@ launch = true
 
 [metadata]
 description = "set dependency management for run sessions"
-version = "0.0.1"
+version = "0.0.2"
 EOL

--- a/buildpacks/python-dependency-manager/buildpack.toml
+++ b/buildpacks/python-dependency-manager/buildpack.toml
@@ -4,7 +4,7 @@ api = "0.11"
 # Buildpack ID and metadata
 [buildpack]
 id = "renku/python-dependency-manager"
-version = "0.0.1"
+version = "0.0.2"
 name = "python dependency manager buildpack"
 description = "A simple buildpack that requires the dependency manager for python"
 


### PR DESCRIPTION
I  manually published 0.0.2 version of:
- all buildpacks
- the builder
- the base image