### PR TITLE
feat: Add tini process manager to jupyterlab

### DIFF
--- a/builders/selector/builder.toml
+++ b/builders/selector/builder.toml
@@ -22,6 +22,10 @@ description = "Builder for Renku frontends and environments."
   version = "0.0.2"
 
 [[buildpacks]]
+  uri = "https://github.com/paketo-buildpacks/tini/releases/download/v0.3.2/tini-0.3.2.cnb"
+  version = "0.3.2"
+
+[[buildpacks]]
   uri = "docker://gcr.io/paketo-buildpacks/python:2.24.3"
   version = "2.24.3"
 
@@ -35,6 +39,9 @@ description = "Builder for Renku frontends and environments."
 
 [[order]]
 
+  [[order.group]]
+    id = "paketo-buildpacks/tini"
+    version = "0.3.2"
   [[order.group]]
    id = "paketo-buildpacks/miniconda"
    version = "0.10.4"
@@ -65,6 +72,9 @@ description = "Builder for Renku frontends and environments."
 
 [[order]]
 
+  [[order.group]]
+    id = "paketo-buildpacks/tini"
+    version = "0.3.2"
   [[order.group]]
    id = "paketo-buildpacks/miniconda"
    version = "0.10.4"

--- a/buildpacks/jupyterlab/bin/build
+++ b/buildpacks/jupyterlab/bin/build
@@ -59,7 +59,7 @@ EOL
 cat >"${layers_dir}/launch.toml" <<EOL
 [[processes]]
 type = "jupyterlab"
-command = ["jupyterlab-entrypoint.sh"]
-args = []
+command = ["tini", "-g", "--"]
+args = ["bash", "jupyterlab-entrypoint.sh"]
 default = true
 EOL

--- a/buildpacks/jupyterlab/bin/detect
+++ b/buildpacks/jupyterlab/bin/detect
@@ -19,6 +19,12 @@ cat >"${CNB_BUILD_PLAN_PATH}" <<EOL
   name = "jupyterlab"
 
 [[requires]]
+  name = "tini"
+
+[requires.metadata]
+  launch = true
+
+[[requires]]
   name = "jupyterlab"
 
 [requires.metadata]

--- a/buildpacks/rstudio/bin/build
+++ b/buildpacks/rstudio/bin/build
@@ -28,18 +28,6 @@ mkdir -p /tmp/rstudio
 dpkg -x "$cache_layer_dir/$FNAME" "/tmp/rstudio"
 cp -r /tmp/rstudio/usr/lib/rstudio-server/* "$rstudio_layer_dir/"
 
-TINI_VERSION="v0.19.0"
-if [ -f "$cache_layer_dir/tini-$TINI_VERSION" ]; then
-	echo "Found tini $TINI_VERSION in $cache_layer_dir skipping download"
-else
-	echo "Downloading tini $TINI_VERSION in $cache_layer_dir"
-	curl -sSL "https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini-amd64" -o "$cache_layer_dir/tini-$TINI_VERSION"
-fi
-
-echo "Installing tini $TINI_VERSION to $rstudio_layer_dir/bin"
-cp "$cache_layer_dir/tini-$TINI_VERSION" "$rstudio_layer_dir/bin/tini"
-chmod a+x "$rstudio_layer_dir/bin/tini"
-
 echo "Setting up launch environment variables"
 mkdir -p "${launch_env_dir}"
 printf "0.0.0.0" >"${launch_env_dir}/RENKU_SESSION_IP.default"

--- a/buildpacks/rstudio/bin/detect
+++ b/buildpacks/rstudio/bin/detect
@@ -17,10 +17,16 @@ cat >"${CNB_BUILD_PLAN_PATH}" <<EOL
 
 [requires.metadata]
   launch = true
-  
+
+[[requires]]
+  name = "tini"
+
+[requires.metadata]
+  launch = true
+
 [[requires]]
   name = "conda"
-  
+
 [requires.metadata]
   build = true
 EOL


### PR DESCRIPTION
This pr introduces the `tini` process manager to the jupyterlab buildpack. 

- Adds `tini` buildpack to the builder definition.
- Modifies the jupyterlab entrypoint to use `tini` for managing subprocesses.
- Updates the rstudio buildpack to remove the custom `tini` installation and rely on the buildpack.
