### PR TITLE
chore: fix base builder version

### DIFF
--- a/builders/selector/builder.toml
+++ b/builders/selector/builder.toml
@@ -83,7 +83,7 @@ description = "Builder for Renku frontends and environments."
     version = "0.0.4"
 
 [stack]
-  build-image = "docker.io/paketobuildpacks/builder-jammy-buildpackless-full:0.0.456"
+  build-image = "docker.io/paketobuildpacks/builder-jammy-buildpackless-full:0.0.256"
   id = "io.buildpacks.stacks.jammy"
   run-image = "ghcr.io/swissdatasciencecenter/renku-frontend-buildpacks/base-image:0.0.4"
   run-image-mirrors = []


### PR DESCRIPTION
This got accidentally set in #43 

But in the release that was published we have the right number.

