### PR TITLE
fix: jupyterlab terminal work directory

### DIFF
--- a/buildpacks/jupyterlab/bin/build
+++ b/buildpacks/jupyterlab/bin/build
@@ -31,19 +31,7 @@ printf "/workspace" >"${launch_env_dir}/RENKU_MOUNT_DIR.default"
 printf "/workspace" >"${launch_env_dir}/RENKU_WORKING_DIR.default"
 printf "/" >"${launch_env_dir}/RENKU_BASE_URL_PATH.default"
 
-cat >"${jupyter_layer_dir}"/bin/jupyterlab-entrypoint.sh <<EOL
-#!/usr/bin/env bash
-SHELL=/bin/bash "${jupyter_environment_dir}/bin/python" -E "${jupyter_environment_dir}/bin/jupyter-lab" \
-        --ip "\${RENKU_SESSION_IP}" \
-        --port "\${RENKU_SESSION_PORT}" \
-        --ServerApp.base_url "\$RENKU_BASE_URL_PATH" \
-        --IdentityProvider.token "" \
-        --ServerApp.password "" \
-        --ServerApp.allow_remote_access true \
-        --ContentsManager.allow_hidden true \
-        --ServerApp.root_dir "\${RENKU_WORKING_DIR}" \
-        --KernelSpecManager.ensure_native_kernel False
-EOL
+cp "${buildpack_dir}/bin/jupyterlab-entrypoint.sh" "${jupyter_layer_dir}/bin/jupyterlab-entrypoint.sh"
 chmod ug+x "${jupyter_layer_dir}"/bin/jupyterlab-entrypoint.sh
 
 # Write layer metadata (CNB requirement)
@@ -61,6 +49,6 @@ cat >"${layers_dir}/launch.toml" <<EOL
 [[processes]]
 type = "jupyterlab"
 command = ["tini", "-g", "--"]
-args = ["bash", "jupyterlab-entrypoint.sh"]
+args = ["bash", "${jupyter_layer_dir}/bin/jupyterlab-entrypoint.sh", "${jupyter_environment_dir}"]
 default = true
 EOL

--- a/buildpacks/jupyterlab/bin/jupyterlab-entrypoint.sh
+++ b/buildpacks/jupyterlab/bin/jupyterlab-entrypoint.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+JUPYTER_ENV_DIR=$1
+
+if [ -z "$JUPYTER_ENV_DIR" ]; then
+	echo "WARNING: Running with JUPYTER_ENV_DIR not set at all, this means python and jupyter executables are expected at /bin/."
+fi
+
+if [ -n "$RENKU_WORKING_DIR" ]; then
+	if [ ! -d "$RENKU_WORKING_DIR" ]; then
+		mkdir -p "$RENKU_WORKING_DIR"
+	fi
+	# This allows the terminal in jupyterlab to open in the working directory
+	cd "$RENKU_WORKING_DIR"
+	# The ServerApp.root_dir further below only changes the file browser location in the Jupyter UI
+fi
+
+"${JUPYTER_ENV_DIR}/bin/python" -E "${JUPYTER_ENV_DIR}/bin/jupyter-lab" \
+	--ip "${RENKU_SESSION_IP}" \
+	--port "${RENKU_SESSION_PORT}" \
+	--ServerApp.base_url "$RENKU_BASE_URL_PATH" \
+	--IdentityProvider.token "" \
+	--ServerApp.password "" \
+	--ServerApp.allow_remote_access true \
+	--ContentsManager.allow_hidden true \
+	--ServerApp.root_dir "${RENKU_WORKING_DIR}" \
+	--KernelSpecManager.ensure_native_kernel False


### PR DESCRIPTION
I saw that on renku CI deployments the terminal does not open in the working directory.

This fixes that. 
