### PR TITLE
chore: bump versions for 0.0.5 release

### DIFF
--- a/builders/selector/builder.toml
+++ b/builders/selector/builder.toml
@@ -7,19 +7,19 @@ description = "Builder for Renku frontends and environments."
 
 [[buildpacks]]
   uri = "../../buildpacks/kernel-installer"
-  version = "0.0.4"
+  version = "0.0.5"
 
 [[buildpacks]]
   uri = "../../buildpacks/jupyterlab"
-  version = "0.0.4"
+  version = "0.0.5"
 
 [[buildpacks]]
   uri = "../../buildpacks/python-dependency-manager"
-  version = "0.0.4"
+  version = "0.0.5"
 
 [[buildpacks]]
   uri = "../../buildpacks/rstudio"
-  version = "0.0.4"
+  version = "0.0.5"
 
 [[buildpacks]]
   uri = "https://github.com/paketo-buildpacks/tini/releases/download/v0.3.2/tini-0.3.2.cnb"
@@ -50,13 +50,13 @@ description = "Builder for Renku frontends and environments."
     version = "2.24.3"
   [[order.group]]
     id = "renku/python-dependency-manager"
-    version = "0.0.4"
+    version = "0.0.5"
   [[order.group]]
     id = "renku/jupyterlab"
-    version = "0.0.4"
+    version = "0.0.5"
   [[order.group]]
     id = "renku/kernel-installer"
-    version = "0.0.4"
+    version = "0.0.5"
 
 [[order]]
 
@@ -65,7 +65,7 @@ description = "Builder for Renku frontends and environments."
     version = "2.24.3"
   [[order.group]]
     id = "renku/python-dependency-manager"
-    version = "0.0.4"
+    version = "0.0.5"
   [[order.group]]
     id = "vscodium"
     version = "0.3.0"
@@ -80,7 +80,7 @@ description = "Builder for Renku frontends and environments."
    version = "0.10.4"
   [[order.group]]
     id = "renku/rstudio"
-    version = "0.0.4"
+    version = "0.0.5"
 
 [stack]
   build-image = "docker.io/paketobuildpacks/builder-jammy-buildpackless-full:0.0.256"

--- a/buildpacks/jupyterlab/bin/build
+++ b/buildpacks/jupyterlab/bin/build
@@ -41,7 +41,7 @@ launch = true
 
 [metadata]
 description = "jupyterlab frontend for renku"
-version = "0.0.4"
+version = "0.0.5"
 EOL
 
 # 4. SET DEFAULT START COMMAND

--- a/buildpacks/jupyterlab/buildpack.toml
+++ b/buildpacks/jupyterlab/buildpack.toml
@@ -3,7 +3,7 @@ api = "0.11"
 [buildpack]
 id = "renku/jupyterlab"
 name = "Jupyterlab frontend Buildpack"
-version = "0.0.4"
+version = "0.0.5"
 
 [[targets]]
   os = "linux"

--- a/buildpacks/kernel-installer/buildpack.toml
+++ b/buildpacks/kernel-installer/buildpack.toml
@@ -4,7 +4,7 @@ api = "0.11"
 # Buildpack ID and metadata
 [buildpack]
 id = "renku/kernel-installer"
-version = "0.0.4"
+version = "0.0.5"
 name = "jupyter kernel installer"
 
 # Targets the buildpack will work with

--- a/buildpacks/python-dependency-manager/bin/build
+++ b/buildpacks/python-dependency-manager/bin/build
@@ -24,5 +24,5 @@ launch = true
 
 [metadata]
 description = "set dependency management for run sessions"
-version = "0.0.4"
+version = "0.0.5"
 EOL

--- a/buildpacks/python-dependency-manager/buildpack.toml
+++ b/buildpacks/python-dependency-manager/buildpack.toml
@@ -4,7 +4,7 @@ api = "0.11"
 # Buildpack ID and metadata
 [buildpack]
 id = "renku/python-dependency-manager"
-version = "0.0.4"
+version = "0.0.5"
 name = "python dependency manager buildpack"
 description = "A simple buildpack that requires the dependency manager for python"
 

--- a/buildpacks/rstudio/bin/build
+++ b/buildpacks/rstudio/bin/build
@@ -53,7 +53,7 @@ launch = true
 
 [metadata]
 description = "rstudio frontend for renku"
-version = "0.0.4"
+version = "0.0.5"
 EOL
 
 cat >"${layers_dir}/r.toml" <<EOL
@@ -62,7 +62,7 @@ launch = true
 
 [metadata]
 description = "r"
-version = "0.0.4"
+version = "0.0.5"
 EOL
 
 cat >"${layers_dir}/cache.toml" <<EOL

--- a/buildpacks/rstudio/buildpack.toml
+++ b/buildpacks/rstudio/buildpack.toml
@@ -3,7 +3,7 @@ api = "0.11"
 [buildpack]
 id = "renku/rstudio"
 name = "RStudio frontend Buildpack"
-version = "0.0.4"
+version = "0.0.5"
 
 [[targets]]
   os = "linux"


### PR DESCRIPTION
New version bumps before we tag a release. Some of these can be probably eliminated. And the rest can be automated. But we do not have that in place yet.

