### PR TITLE
Fixes for Renku Buildpacks and Shell Environment

### DIFF
--- a/builders/selector/builder.toml
+++ b/builders/selector/builder.toml
@@ -26,12 +26,12 @@ description = "Builder for Renku frontends and environments."
   version = "0.3.2"
 
 [[buildpacks]]
-  uri = "docker://gcr.io/paketo-buildpacks/python:2.24.3"
+  uri = "docker://docker.io/paketobuildpacks/python:2.24.3"
   version = "2.24.3"
 
 [[buildpacks]]
   id = "paketo-buildpacks/miniconda"
-  uri = "docker://gcr.io/paketo-buildpacks/miniconda:0.10.4"
+  uri = "docker://docker.io/paketobuildpacks/miniconda:0.10.4"
   version = "0.10.4"
 
 [lifecycle]

--- a/buildpacks/jupyterlab/bin/build
+++ b/buildpacks/jupyterlab/bin/build
@@ -25,6 +25,7 @@ jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
 conda deactivate
 
 mkdir -p "${launch_env_dir}"
+printf "/bin/bash" >"${launch_env_dir}/SHELL.default"
 printf "0.0.0.0" >"${launch_env_dir}/RENKU_SESSION_IP.default"
 printf "8000" >"${launch_env_dir}/RENKU_SESSION_PORT.default"
 printf "/workspace" >"${launch_env_dir}/RENKU_MOUNT_DIR.default"

--- a/buildpacks/jupyterlab/bin/jupyterlab-entrypoint.sh
+++ b/buildpacks/jupyterlab/bin/jupyterlab-entrypoint.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
+#ensure bashrc is sourced
+# shellcheck source=/dev/null
+source "${HOME}"/.bashrc
+
 JUPYTER_ENV_DIR=$1
 
 if [ -z "$JUPYTER_ENV_DIR" ]; then

--- a/run-image/.bashrc
+++ b/run-image/.bashrc
@@ -1,4 +1,13 @@
 # shellcheck shell=bash
+
+# enable programmable completion features (you don't need to enable
+# this, if it's already enabled in /etc/bash.bashrc and /etc/profile
+# sources /etc/bash.bashrc).
+if [ -f /etc/bash_completion ] && ! shopt -oq posix; then
+      # shellcheck source=/dev/null
+      . /etc/bash_completion
+fi
+
 # Setup git user
 if [[ -z "$(git config --global --get user.name)" && -v GIT_AUTHOR_NAME ]]; then
     git config --global user.name "$GIT_AUTHOR_NAME"


### PR DESCRIPTION
### Summary:

This pull request introduces several important fixes across the Renku buildpack system, primarily focusing on  the shell environment within the built images.

Key changes include  updating Paketo buildpack sources due to `gcr.io` discontinuation for paketo buildpacks, and implementing various shell-related fixes to ensure consistent and user-friendly environments for JupyterLab and general run images.

### Key Changes Introduced:

*   **JupyterLab Shell Environment Improvements:**
    *   Explicitly set `/bin/bash` as the default shell for JupyterLab environments by adding `printf "/bin/bash" >"${launch_env_dir}/SHELL.default"` in `buildpacks/jupyterlab/bin/build`.
    *   Ensured that `~/.bashrc` is sourced at the start of the JupyterLab entrypoint script (`buildpacks/jupyterlab/bin/jupyterlab-entrypoint.sh`) to correctly load bash completion and other configurations.
*   **General Shell Environment Enhancements:**
    *   Enabled programmable bash completion features in the `run-image/.bashrc` file, improving the interactive shell experience for users.
