### PR TITLE
fix: update run image version to 0.0.6

### DIFF
--- a/builders/selector/builder.toml
+++ b/builders/selector/builder.toml
@@ -85,5 +85,5 @@ description = "Builder for Renku frontends and environments."
 [stack]
   build-image = "docker.io/paketobuildpacks/builder-jammy-buildpackless-full:0.0.256"
   id = "io.buildpacks.stacks.jammy"
-  run-image = "ghcr.io/swissdatasciencecenter/renku-frontend-buildpacks/base-image:0.0.4"
+  run-image = "ghcr.io/swissdatasciencecenter/renku-frontend-buildpacks/base-image:0.0.6"
   run-image-mirrors = []


### PR DESCRIPTION
After this I will re-issue the 0.0.6 release and re-publish the builder image.