### PR TITLE
Introduce TTYD Frontend and Add Tmux for Terminal Convenience

### DIFF
--- a/builders/selector/builder.toml
+++ b/builders/selector/builder.toml
@@ -14,6 +14,10 @@ description = "Builder for Renku frontends and environments."
   version = "0.0.6"
 
 [[buildpacks]]
+  uri = "../../buildpacks/ttyd"
+  version = "0.0.6"
+
+[[buildpacks]]
   uri = "../../buildpacks/python-dependency-manager"
   version = "0.0.6"
 
@@ -56,6 +60,21 @@ description = "Builder for Renku frontends and environments."
     version = "0.0.6"
   [[order.group]]
     id = "renku/kernel-installer"
+    version = "0.0.6"
+
+[[order]]
+
+  [[order.group]]
+    id = "paketo-buildpacks/tini"
+    version = "0.3.2"
+  [[order.group]]
+    id = "paketo-buildpacks/python"
+    version = "2.24.3"
+  [[order.group]]
+    id = "renku/python-dependency-manager"
+    version = "0.0.6"
+  [[order.group]]
+    id = "renku/ttyd"
     version = "0.0.6"
 
 [[order]]

--- a/buildpacks/ttyd/bin/build
+++ b/buildpacks/ttyd/bin/build
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+echo "=== Renku TTYD buildpack ==="
+
+layers_dir="${CNB_LAYERS_DIR}"
+buildpack_dir="${CNB_BUILDPACK_DIR}"
+ttyd_layer_dir="${layers_dir}"/ttyd
+launch_env_dir="${ttyd_layer_dir}"/env.launch
+ttyd_bin_dir="${ttyd_layer_dir}"/bin
+mkdir -p "${ttyd_bin_dir}"
+mkdir -p "${launch_env_dir}"
+
+ARCH=$(uname -i)
+TTYD_VERSION="1.7.7"
+TTYD_URL="https://github.com/tsl0922/ttyd/releases/download/${TTYD_VERSION}/ttyd.${ARCH}"
+
+cd "${ttyd_bin_dir}"
+curl -Lo ttyd "${TTYD_URL}"
+chmod 755 ttyd
+cp "${buildpack_dir}/bin/ttyd-entrypoint.sh" "${ttyd_bin_dir}/ttyd-entrypoint.sh"
+chmod 755 "${ttyd_bin_dir}"/ttyd-entrypoint.sh
+
+mkdir -p "${launch_env_dir}"
+printf "/bin/bash" >"${launch_env_dir}/SHELL.default"
+printf "0.0.0.0" >"${launch_env_dir}/RENKU_SESSION_IP.default"
+printf "8000" >"${launch_env_dir}/RENKU_SESSION_PORT.default"
+printf "/workspace" >"${launch_env_dir}/RENKU_MOUNT_DIR.default"
+printf "/workspace" >"${launch_env_dir}/RENKU_WORKING_DIR.default"
+printf "/" >"${launch_env_dir}/RENKU_BASE_URL_PATH.default"
+
+
+# Write layer metadata (CNB requirement)
+cat >"${layers_dir}/ttyd.toml" <<EOL
+[types]
+launch = true
+
+[metadata]
+description = "ttyd frontend for renku"
+version = "0.0.6"
+EOL
+
+# 4. SET DEFAULT START COMMAND
+cat >"${layers_dir}/launch.toml" <<EOL
+[[processes]]
+type = "ttyd"
+command = ["tini", "-g", "--"]
+args = ["bash", "${ttyd_bin_dir}/ttyd-entrypoint.sh"]
+default = true
+EOL

--- a/buildpacks/ttyd/bin/detect
+++ b/buildpacks/ttyd/bin/detect
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+echo "Checking if ttyd frontend should be installed..."
+if [[ "${BP_RENKU_FRONTENDS}" =~ "ttyd" ]]; then
+  echo "The BP_RENKU_FRONTENDS environment variable was found to contain ttyd and the buildpack will be applied"
+else
+  echo "The BP_RENKU_FRONTENDS environment variable is not set or does not contain ttyd, will not apply this buildpack"
+  exit 100
+fi
+
+cat >"${CNB_BUILD_PLAN_PATH}" <<EOL
+[[provides]]
+  name = "ttyd"
+
+[[requires]]
+  name = "tini"
+
+[requires.metadata]
+  launch = true
+
+[[requires]]
+  name = "ttyd"
+
+[requires.metadata]
+  launch = true
+EOL

--- a/buildpacks/ttyd/bin/ttyd-entrypoint.sh
+++ b/buildpacks/ttyd/bin/ttyd-entrypoint.sh
@@ -9,8 +9,10 @@ RENKU_SESSION_PORT="${RENKU_SESSION_PORT:-8888}"
 RENKU_WORKING_DIR="${RENKU_WORKING_DIR:-${HOME}}"
 RENKU_BASE_URL_PATH="${RENKU_BASE_URL_PATH:-/}"
 
+TTYD_CMD=$(which tmux >/dev/null && echo "tmux attach || tmux" || echo "bash")
+
 ttyd \
   --cwd "${RENKU_WORKING_DIR:-${HOME}}" \
   --port "${RENKU_SESSION_PORT:-8888}" \
   --base-path "${RENKU_BASE_URL_PATH:-/}" \
-  --writable sh -c 'tmux attach || tmux'
+  --writable sh -c "${TTYD_CMD}"

--- a/buildpacks/ttyd/bin/ttyd-entrypoint.sh
+++ b/buildpacks/ttyd/bin/ttyd-entrypoint.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+#ensure bashrc is sourced
+# shellcheck source=/dev/null
+source "${HOME}"/.bashrc
+
+RENKU_SESSION_PORT="${RENKU_SESSION_PORT:-8888}"
+RENKU_WORKING_DIR="${RENKU_WORKING_DIR:-${HOME}}"
+RENKU_BASE_URL_PATH="${RENKU_BASE_URL_PATH:-/}"
+
+ttyd --cwd "${RENKU_WORKING_DIR}" --port "${RENKU_SESSION_PORT}" --base-path "${RENKU_BASE_URL_PATH}" --writable bash

--- a/buildpacks/ttyd/bin/ttyd-entrypoint.sh
+++ b/buildpacks/ttyd/bin/ttyd-entrypoint.sh
@@ -9,4 +9,8 @@ RENKU_SESSION_PORT="${RENKU_SESSION_PORT:-8888}"
 RENKU_WORKING_DIR="${RENKU_WORKING_DIR:-${HOME}}"
 RENKU_BASE_URL_PATH="${RENKU_BASE_URL_PATH:-/}"
 
-ttyd --cwd "${RENKU_WORKING_DIR}" --port "${RENKU_SESSION_PORT}" --base-path "${RENKU_BASE_URL_PATH}" --writable bash
+ttyd \
+  --cwd "${RENKU_WORKING_DIR:-${HOME}}" \
+  --port "${RENKU_SESSION_PORT:-8888}" \
+  --base-path "${RENKU_BASE_URL_PATH:-/}" \
+  --writable sh -c 'tmux attach || tmux'

--- a/buildpacks/ttyd/buildpack.toml
+++ b/buildpacks/ttyd/buildpack.toml
@@ -1,0 +1,10 @@
+api = "0.11"
+
+[buildpack]
+id = "renku/ttyd"
+name = "ttyd frontend Buildpack"
+version = "0.0.6"
+
+[[targets]]
+  os = "linux"
+  arch = "amd64"

--- a/buildpacks/ttyd/package.toml
+++ b/buildpacks/ttyd/package.toml
@@ -1,0 +1,2 @@
+[buildpack]
+  uri = "."

--- a/run-image/Dockerfile
+++ b/run-image/Dockerfile
@@ -34,6 +34,7 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
     netcat-traditional \
     rclone \
     unzip \
+    tmux \
     vim && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \


### PR DESCRIPTION
**Description:**
This pull request introduces `ttyd` as a new frontend option for Renku environments, allowing users to access a web-based terminal directly. Additionally, `tmux` has been added to the run image to enhance terminal convenience and session management.

**Key Changes:**
- **TTYD Integration:**
    - Added a new `ttyd` buildpack responsible for downloading and configuring the `ttyd` terminal.
    - Integrated `ttyd` into the `selector` builder, enabling it as a selectable frontend.
    - Defined `ttyd`'s build and detect logic, ensuring it's applied when specified by the `BP_RENKU_FRONTENDS` environment variable.
    - Configured `ttyd` to use `tini` as its init process and defined an entrypoint script for proper environment setup.
- **Tmux Addition:**
    - `tmux` has been added to the `run-image/Dockerfile`, providing users with a powerful terminal multiplexer for improved workflow.

**Benefits:**
- **Web-based Terminal Access:** Users can now get a persistent web-based terminal through `ttyd`, which can be very useful for quick command-line interactions without needing a full JupyterLab interface.
- **Enhanced Terminal Experience:** The inclusion of `tmux` allows for better session management, multiple panes, and persistent terminal sessions, improving the overall terminal experience within Renku environments.

**How to Test:**
1. Build the updated environment with the `ttyd` frontend enabled (e.g., by setting `BP_RENKU_FRONTENDS=ttyd`).
2. Verify that the `ttyd` web terminal is accessible.
3. Confirm that `tmux` is available and functional within the terminal.

closes #56 