### PR TITLE
chore: do not install poetry in package mode

### DIFF
--- a/samples/poetry/pyproject.toml
+++ b/samples/poetry/pyproject.toml
@@ -5,6 +5,7 @@ description = "sample test for buildpacks"
 authors = ["Salim Kayal <salim.kayal@idiap.ch>"]
 license = "MIT"
 readme = "README.md"
+package-mode = false
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.13"


### PR DESCRIPTION
Fixes the following warning with current`pyproject.toml`: 

```
[builder]       Warning: The current project could not be installed: [Errno 2] No such file or directory: '/workspace/README.md'
[builder]       If you do not want to install the current project use --no-root.
[builder]       If you want to use Poetry only for dependency management but not for packaging, you can disable package mode by setting package-mode = false in your pyproject.toml file.
[builder]       In a future version of Poetry this warning will become an error!
```

