### PR TITLE
chore: add a conda-nodefaults buildpack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 e2e.test
+.vscode

--- a/builders/selector/builder.toml
+++ b/builders/selector/builder.toml
@@ -6,6 +6,10 @@ description = "Builder for Renku frontends and environments."
   version = "0.3.0"
 
 [[buildpacks]]
+  uri = "../../buildpacks/conda-nodefaults"
+  version = "0.0.1"
+
+[[buildpacks]]
   uri = "../../buildpacks/kernel-installer"
   version = "0.0.6"
 
@@ -44,6 +48,9 @@ description = "Builder for Renku frontends and environments."
 [[order]]
 
   [[order.group]]
+    id = "renku/conda-nodefaults"
+    version = "0.0.1"
+  [[order.group]]
     id = "paketo-buildpacks/tini"
     version = "0.3.2"
   [[order.group]]
@@ -68,6 +75,9 @@ description = "Builder for Renku frontends and environments."
     id = "paketo-buildpacks/tini"
     version = "0.3.2"
   [[order.group]]
+    id = "renku/conda-nodefaults"
+    version = "0.0.1"
+  [[order.group]]
     id = "paketo-buildpacks/python"
     version = "2.24.3"
   [[order.group]]
@@ -80,6 +90,9 @@ description = "Builder for Renku frontends and environments."
 [[order]]
 
   [[order.group]]
+    id = "renku/conda-nodefaults"
+    version = "0.0.1"
+  [[order.group]]
     id = "paketo-buildpacks/python"
     version = "2.24.3"
   [[order.group]]
@@ -91,6 +104,9 @@ description = "Builder for Renku frontends and environments."
 
 [[order]]
 
+  [[order.group]]
+    id = "renku/conda-nodefaults"
+    version = "0.0.1"
   [[order.group]]
     id = "paketo-buildpacks/tini"
     version = "0.3.2"

--- a/builders/selector/builder.toml
+++ b/builders/selector/builder.toml
@@ -75,14 +75,13 @@ value = "vscodium"
     version = "0.0.6"
 
 [[order]]
-
-  [[order.group]]
-    id = "paketo-buildpacks/tini"
-    version = "0.3.2"
   [[order.group]]
     id = "renku/conda-nodefaults"
     version = "0.0.1"
     optional = true
+  [[order.group]]
+    id = "paketo-buildpacks/tini"
+    version = "0.3.2"
   [[order.group]]
     id = "paketo-buildpacks/python"
     version = "2.24.3"

--- a/builders/selector/builder.toml
+++ b/builders/selector/builder.toml
@@ -1,5 +1,9 @@
 description = "Builder for Renku frontends and environments."
 
+[[build.env]]
+name = "BP_RENKU_FRONTENDS"
+value = "vscodium"
+
 [[buildpacks]]
   uri = "docker://ghcr.io/swissdatasciencecenter/vscodium-buildpack/vscodium:0.3.0"
   id = "vscodium"

--- a/builders/selector/builder.toml
+++ b/builders/selector/builder.toml
@@ -54,6 +54,7 @@ value = "vscodium"
   [[order.group]]
     id = "renku/conda-nodefaults"
     version = "0.0.1"
+    optional = true
   [[order.group]]
     id = "paketo-buildpacks/tini"
     version = "0.3.2"
@@ -81,6 +82,7 @@ value = "vscodium"
   [[order.group]]
     id = "renku/conda-nodefaults"
     version = "0.0.1"
+    optional = true
   [[order.group]]
     id = "paketo-buildpacks/python"
     version = "2.24.3"
@@ -96,6 +98,7 @@ value = "vscodium"
   [[order.group]]
     id = "renku/conda-nodefaults"
     version = "0.0.1"
+    optional = true
   [[order.group]]
     id = "paketo-buildpacks/python"
     version = "2.24.3"
@@ -111,6 +114,7 @@ value = "vscodium"
   [[order.group]]
     id = "renku/conda-nodefaults"
     version = "0.0.1"
+    optional = true
   [[order.group]]
     id = "paketo-buildpacks/tini"
     version = "0.3.2"

--- a/buildpacks/conda-nodefaults/bin/build
+++ b/buildpacks/conda-nodefaults/bin/build
@@ -15,6 +15,9 @@ TMPDIR=$(mktemp -d)
 cp environment.yml "$TMPDIR/original.yml"
 
 # Download latest yq binary
+cache_layer_dir="${CNB_LAYERS_DIR}"/cache
+mkdir -p "${cache_layer_dir}"
+
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 ARCH=$(uname -m)
 
@@ -25,17 +28,24 @@ case "$ARCH" in
 esac
 
 YQ_FILENAME="yq_${OS}_${ARCH}"
-YQ_URL="https://github.com/mikefarah/yq/releases/latest/download/${YQ_FILENAME}"
-YQ_BIN="$TMPDIR/yq"
+YQ_VERSION=v4.47.1
+YQ_URL="https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/${YQ_FILENAME}"
+YQ_BIN="${cache_layer_dir}/yq"
 
-curl -fsSL "$YQ_URL" -o "$YQ_BIN"
-chmod +x "$YQ_BIN"
+if [ -f "$cache_layer_dir/${YQ_FILENAME}" ]; then
+	echo "Found yq $YQ_VERSION in $cache_layer_dir skipping download"
+else
+	echo "Downloading yq $YQ_VERSION in $cache_layer_dir from $YQ_URL"
+
+	curl -fsSL "$YQ_URL" -o "${YQ_BIN}"
+  chmod +x "$YQ_BIN"
+fi
 
 # Ensure 'channels' exists (set to empty if missing)
 "$YQ_BIN" eval -i '.channels = (.channels // [])' $ENV_FILE
 
 # Fail if "defaults" is in the channels list
-if "$YQ_BIN" '.channels | any_c(. == "defaults")' $ENV_FILE | grep -q true; then
+if "$YQ_BIN" --exit-status '.channels | any_c(. == "defaults")' $ENV_FILE; then
     echo -e "\n\033[1m!!! defaults channel detected !!! \033[0m"
     echo -e "Failing to avoid rate limits from Anaconda. Please remove the \033[1mdefaults\033[0m channel from \033[1menvironment.yml\033[1m from and rerun."
     exit 100

--- a/buildpacks/conda-nodefaults/bin/build
+++ b/buildpacks/conda-nodefaults/bin/build
@@ -1,23 +1,39 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+echo -e "🔧 \033[1mConda Channel Cleanup Buildpack\033[0m"
+
 ENV_FILE="environment.yml"
 
 # Exit silently if environment.yml is not present
 [[ -f "$ENV_FILE" ]] || exit 0
+
+# Save original version for diff
+TMPDIR=$(mktemp -d)
+cp environment.yml "$TMPDIR/original.yml"
 
 # Download latest yq binary (Go version)
 YQ_BIN="$(mktemp -d)/yq"
 curl -sSL https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -o "$YQ_BIN"
 chmod +x "$YQ_BIN"
 
-# Step 1: Ensure 'channels' exists (set to empty if missing)
+# Ensure 'channels' exists (set to empty if missing)
 "$YQ_BIN" eval -i '.channels = (.channels // [])' $ENV_FILE
 
-# Step 2: Remove 'defaults'
-"$YQ_BIN" eval -i '.channels = (.channels - ["defaults"])' $ENV_FILE
+# Fail if "defaults" is in the channels list
+if "$YQ_BIN" '.channels | any_c(. == "defaults")' $ENV_FILE > /dev/null 2>&1; then
+    echo -e "\n\033[1m!!! defaults channel detected !!! \033[0m"
+    echo -e "Failing to avoid rate limits from Anaconda. Please remove the \033[1mdefaults\033[0m channel from \033[1menvironment.yml\033[1m from and rerun."
+    exit 100
+fi
 
-# Step 3: Add 'nodefaults' if not already present
+# Add 'nodefaults' if not already present
 "$YQ_BIN" -i '.channels |= (. + "nodefaults" | unique)' $ENV_FILE
 
-cat $ENV_FILE
+# Show diff if there are changes
+echo -e "\n\033[1mChanges to environment.yml:\033[0m"
+if diff -u "$TMPDIR/original.yml" environment.yml; then
+  echo "No changes made."
+else
+  echo -e "\n✅ environment.yml updated."
+fi

--- a/buildpacks/conda-nodefaults/bin/build
+++ b/buildpacks/conda-nodefaults/bin/build
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ENV_FILE="environment.yml"
+
+# Exit silently if environment.yml is not present
+[[ -f "$ENV_FILE" ]] || exit 0
+
+# Download latest yq binary (Go version)
+YQ_BIN="$(mktemp -d)/yq"
+curl -sSL https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -o "$YQ_BIN"
+chmod +x "$YQ_BIN"
+
+# Step 1: Ensure 'channels' exists (set to empty if missing)
+"$YQ_BIN" eval -i '.channels = (.channels // [])' $ENV_FILE
+
+# Step 2: Remove 'defaults'
+"$YQ_BIN" eval -i '.channels = (.channels - ["defaults"])' $ENV_FILE
+
+# Step 3: Add 'nodefaults' if not already present
+"$YQ_BIN" -i '.channels |= (. + "nodefaults" | unique)' $ENV_FILE
+
+cat $ENV_FILE

--- a/buildpacks/conda-nodefaults/bin/build
+++ b/buildpacks/conda-nodefaults/bin/build
@@ -5,8 +5,10 @@ echo -e "🔧 \033[1mConda Channel Cleanup Buildpack\033[0m"
 
 ENV_FILE="environment.yml"
 
-# Exit silently if environment.yml is not present
-[[ -f "$ENV_FILE" ]] || exit 0
+if [ ! -f "$ENV_FILE" ]; then
+  echo "Cannot find $ENV_FILE, exiting silently."
+  exit 0
+fi
 
 # Save original version for diff
 TMPDIR=$(mktemp -d)

--- a/buildpacks/conda-nodefaults/bin/build
+++ b/buildpacks/conda-nodefaults/bin/build
@@ -12,16 +12,28 @@ ENV_FILE="environment.yml"
 TMPDIR=$(mktemp -d)
 cp environment.yml "$TMPDIR/original.yml"
 
-# Download latest yq binary (Go version)
-YQ_BIN="$(mktemp -d)/yq"
-curl -sSL https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -o "$YQ_BIN"
+# Download latest yq binary
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+
+case "$ARCH" in
+  x86_64) ARCH=amd64 ;;
+  arm64|aarch64) ARCH=arm64 ;;
+  *) echo "Unsupported architecture: $ARCH"; exit 1 ;;
+esac
+
+YQ_FILENAME="yq_${OS}_${ARCH}"
+YQ_URL="https://github.com/mikefarah/yq/releases/latest/download/${YQ_FILENAME}"
+YQ_BIN="$TMPDIR/yq"
+
+curl -fsSL "$YQ_URL" -o "$YQ_BIN"
 chmod +x "$YQ_BIN"
 
 # Ensure 'channels' exists (set to empty if missing)
 "$YQ_BIN" eval -i '.channels = (.channels // [])' $ENV_FILE
 
 # Fail if "defaults" is in the channels list
-if "$YQ_BIN" '.channels | any_c(. == "defaults")' $ENV_FILE > /dev/null 2>&1; then
+if "$YQ_BIN" '.channels | any_c(. == "defaults")' $ENV_FILE | grep -q true; then
     echo -e "\n\033[1m!!! defaults channel detected !!! \033[0m"
     echo -e "Failing to avoid rate limits from Anaconda. Please remove the \033[1mdefaults\033[0m channel from \033[1menvironment.yml\033[1m from and rerun."
     exit 100
@@ -35,5 +47,5 @@ echo -e "\n\033[1mChanges to environment.yml:\033[0m"
 if diff -u "$TMPDIR/original.yml" environment.yml; then
   echo "No changes made."
 else
-  echo -e "\n✅ environment.yml updated."
+  echo -e "\n✅ environment.yml updated.\n\n"
 fi

--- a/buildpacks/conda-nodefaults/bin/detect
+++ b/buildpacks/conda-nodefaults/bin/detect
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -e
+
+if [ -f "environment.yml" ]; then
+  exit 0  # pass
+else
+  exit 100  # opt-out
+fi

--- a/buildpacks/conda-nodefaults/buildpack.toml
+++ b/buildpacks/conda-nodefaults/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.9"
+api = "0.11"
 
 [buildpack]
 id = "renku/conda-nodefaults"

--- a/buildpacks/conda-nodefaults/buildpack.toml
+++ b/buildpacks/conda-nodefaults/buildpack.toml
@@ -1,0 +1,10 @@
+api = "0.9"
+
+[buildpack]
+id = "renku/conda-nodefaults"
+name = "Conda nodefaults buildpack"
+version = "0.0.1"
+
+[[targets]]
+  os = "linux"
+  arch = "amd64"

--- a/buildpacks/conda-nodefaults/package.toml
+++ b/buildpacks/conda-nodefaults/package.toml
@@ -1,0 +1,2 @@
+[buildpack]
+  uri = "."

--- a/samples/conda-defaults/README.md
+++ b/samples/conda-defaults/README.md
@@ -1,0 +1,3 @@
+## Build with defaults conda channel
+This build should fail with the `selector` builder or using the `conda-nodefaults` buildpack
+because it contains the `defaults` channel in the `environment.yml` spec.

--- a/samples/conda-defaults/environment.yml
+++ b/samples/conda-defaults/environment.yml
@@ -1,0 +1,5 @@
+name: base
+channels:
+  - defaults
+dependencies:
+  - numpy

--- a/tests/e2e/buildpacks_test.go
+++ b/tests/e2e/buildpacks_test.go
@@ -172,4 +172,36 @@ var _ = Describe("Testing samples", Label("samples"), Ordered, func() {
 		},
 		Entry("using random sample", "../../samples/pip"),
 	)
+
+	DescribeTableSubtree(
+		"conda-nodefaults-fail",
+		func(source string) {
+			var image string
+
+			Context("image building", func() {
+				It("should fail when the defaults channel is included", func(ctx SpecContext) {
+				image = strings.ToLower(fmt.Sprintf("test-image-%s", getULID()))
+				err = buildImage(ctx, builderImg, source, image, map[string]string{"BP_RENKU_FRONTENDS": "vscodium"})
+				Expect(err).To(HaveOccurred())
+				})
+			})
+		},
+		Entry("using conda-defaults sample", "../../samples/conda-defaults"),
+	)
+
+	DescribeTableSubtree(
+		"conda-nodefaults-pass",
+		func(source string) {
+			var image string
+			Context("image building", func() {
+				It("should pass when the defaults channel is not included or conda is not used", func(ctx SpecContext) {
+				image = strings.ToLower(fmt.Sprintf("test-image-%s", getULID()))
+				err = buildImage(ctx, builderImg, source, image, map[string]string{"BP_RENKU_FRONTENDS": "vscodium"})
+				Expect(err).ToNot(HaveOccurred())
+				})
+			})
+		},
+		Entry("using conda sample", "../../samples/conda"),
+		Entry("using pip sample", "../../samples/pip"),
+	)
 })


### PR DESCRIPTION
We see a lot of problems with users who have a conda environment but do not have the `nodefaults` channel in their configuration. Their builds fail and they have no idea why. This PR adds a buildpack that tries to fix this by:

- failing with an instruction on what to do _if_ `defaults` is in the conda environment file
- adds the `nodefaults` on-the-fly to prevent the conda buildpack from injecting the defaults channel

A possible alternative to this solution would be to modify the conda configuration after conda is installed - this would have the added benefit of not touching the user's environment file, but it might be harder to fully enforce the exclusion of the defaults channel. 