### PR TITLE
fix: Make Python Dependency Management more robust to image change

### DIFF
--- a/buildpacks/python-dependency-manager/bin/build
+++ b/buildpacks/python-dependency-manager/bin/build
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -eo pipefail
+set -xeou pipefail
 
 layer_dir="${CNB_LAYERS_DIR}/deps"
 execd_dir="${layer_dir}"/exec.d
@@ -9,6 +9,12 @@ cat >"${execd_dir}"/setup.sh <<EOL
 #!/usr/bin/env bash
 set -eo pipefail
 export HOME=\$(eval echo "~\$(id -nu)")
+if [ -d \${RENKU_MOUNT_DIR}/.venv ] && \
+   ([ "\$(readlink \${RENKU_MOUNT_DIR}/.venv/bin/python 2>/dev/null)" != "\$(which python 2>/dev/null)" ] || \
+    [ "\$(grep "version = " \${RENKU_MOUNT_DIR}/.venv/pyvenv.cfg 2>/dev/null | cut -d' ' -f3)" != "\$(python --version 2>/dev/null | cut -d' ' -f2)" ]); then
+    echo "Virtualenv exists but has mismatch - recreating..."
+    rm -rf \${RENKU_MOUNT_DIR}/.venv
+fi
 python -m venv --system-site-packages \${RENKU_MOUNT_DIR}/.venv
 printf 'source \${RENKU_MOUNT_DIR}/.venv/bin/activate' >>  \${HOME}/.bashrc
 source \${RENKU_MOUNT_DIR}/.venv/bin/activate


### PR DESCRIPTION
This PR introduces a fix to the Python dependency management within the Renku Buildpacks. It primarily focuses on improving the robustness of virtual environment handling, especially in scenarios involving persistent volumes and changing base images.

**Motivation:**

Currently, if the built image changes (e.g., due to a Python version update in the base image) while a persistent volume still contains a virtual environment (`.venv`) from a previous build, this can lead to inconsistencies. The existing virtual environment might point to a Python interpreter that no longer exists or is incompatible with the new image, causing issues for users. This change addresses that problem by ensuring the virtual environment is always aligned with the current image's Python installation.

**Key Changes:**

*   **Virtual Environment Validation and Recreation:** The `python-dependency-manager` build script now includes logic to check the integrity of an existing virtual environment (`.venv`) in the `RENKU_MOUNT_DIR`. If a mismatch is detected in the Python executable path or version (which can happen after a base image update), the virtual environment is automatically recreated. This ensures that the environment is always consistent with the system's Python installation provided by the current built image.

These changes aim to provide a more stable and reliable environment for Python-based Renku projects, preventing issues arising from image and persistent volume mismatches.

Related to SwissDataScienceCenter/amalthea#999