### PR TITLE
feat: Add Matrix Based Multi-architecture Builder Support and Enhance Release Workflow

### DIFF
--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -263,7 +263,6 @@ jobs:
         images: ghcr.io/${{ github.repository }}/${{ matrix.builder }}
         tags: |
           type=semver,pattern={{version}},value=${{ needs.move-tag.outputs.version }}${{ (startsWith(github.event.pull_request.base.ref, 'test-release/') && '-test') || '' }}
-          type=semver,pattern={{version}}
         flavor: |
           suffix=-${{ matrix.arch }}
 
@@ -307,7 +306,6 @@ jobs:
         images: ghcr.io/${{ github.repository }}/${{ matrix.builder }}
         tags: |
           type=semver,pattern={{version}},value=${{ needs.move-tag.outputs.version }}${{ (startsWith(github.event.pull_request.base.ref, 'test-release/') && '-test') || '' }}
-          type=semver,pattern={{version}}
 
     - name: Get primary tag
       id: get-tag


### PR DESCRIPTION
This PR significantly enhances our release and build process by introducing multi-architecture support for our builders and streamlining the overall release workflow.

**Key Changes and Features:**

*   **Multi-architecture Builder Support:**
    *   Introduces new `publish-builders` jobs that build and push `amd64` and `arm64` specific images for both `selector` and `cuda-selector` builders. This ensures broader compatibility across different CPU architectures.
    *   Leverages a matrix strategy to efficiently build and publish these architecture-specific images in parallel.
*   **Automated Multi-architecture Manifest Creation:**
    *   A new `create-manifests` job is added to automatically create multi-architecture Docker manifests. This allows users to pull a single builder image tag, and Docker will correctly resolve the architecture-specific image for their system.
*   **Enhanced Buildpack Publishing:**
    *   The `publish-buildpacks` job is now explicitly integrated into the release flow to ensure buildpacks are published as part of the release.
*   **Streamlined Release Workflow:**
    *   The `release` job has been updated to depend on the new `move-tag`, `create-manifests`, and `publish-buildpacks` jobs.
    *   Version extraction and tag handling in the `release` job now accurately reference the outputs from the `move-tag` job, ensuring consistency.