### PR TITLE
feat: add none front-end

### DIFF
--- a/builders/cuda-selector/builder.toml
+++ b/builders/cuda-selector/builder.toml
@@ -25,6 +25,10 @@ description = "CUDA enabled builder for Renku frontends and environments."
   version = "0.8.0"
 
 [[buildpacks]]
+  uri = "../../buildpacks/none-frontend"
+  version = "0.8.0"
+
+[[buildpacks]]
   uri = "../../buildpacks/python-dependency-manager"
   version = "0.8.0"
 
@@ -108,6 +112,54 @@ description = "CUDA enabled builder for Renku frontends and environments."
 
   [[order.group]]
     id = "renku/kernel-installer"
+    version = "0.8.0"
+
+  [[order.group]]
+    id = "heroku/deb-packages"
+    version = "0.2.0"
+    optional = true
+
+  [[order.group]]
+    id = "renku/homebrew"
+    version = "0.8.0"
+    optional = true
+
+  [[order.group]]
+    id = "renku/init-scripts"
+    version = "0.8.0"
+    optional = true
+
+  [[order.group]]
+    id = "paketo-buildpacks/node-engine"
+    version = "8.1.1"
+    optional = true
+
+  [[order.group]]
+    id = "renku/coding-agent"
+    version = "0.8.0"
+    optional = true
+
+[[order]]
+
+  [[order.group]]
+    id = "renku/conda-nodefaults"
+    version = "0.8.0"
+    optional = true
+
+  [[order.group]]
+    id = "paketo-buildpacks/python"
+    version = "2.46.0"
+
+  [[order.group]]
+    id = "renku/python-dependency-manager"
+    version = "0.8.0"
+
+  [[order.group]]
+    id = "renku/renku-variables"
+    version = "0.8.0"
+
+  [[order.group]]
+    id = "renku/none-frontend"
     version = "0.8.0"
 
   [[order.group]]
@@ -303,6 +355,95 @@ description = "CUDA enabled builder for Renku frontends and environments."
 
   [[order.group]]
     id = "renku/rstudio"
+    version = "0.8.0"
+
+  [[order.group]]
+    id = "heroku/deb-packages"
+    version = "0.2.0"
+    optional = true
+
+  [[order.group]]
+    id = "renku/homebrew"
+    version = "0.8.0"
+    optional = true
+
+  [[order.group]]
+    id = "renku/init-scripts"
+    version = "0.8.0"
+    optional = true
+
+[[order]]
+
+  [[order.group]]
+    id = "renku/renku-variables"
+    version = "0.8.0"
+
+  [[order.group]]
+    id = "paketo-buildpacks/miniconda"
+    version = "0.11.22"
+
+  [[order.group]]
+    id = "renku/r-conda"
+    version = "0.8.0"
+
+  [[order.group]]
+    id = "renku/renv"
+    version = "0.8.0"
+
+  [[order.group]]
+    id = "renku/r-dependency-manager"
+    version = "0.8.0"
+
+  [[order.group]]
+    id = "renku/none-frontend"
+    version = "0.8.0"
+
+  [[order.group]]
+    id = "heroku/deb-packages"
+    version = "0.2.0"
+    optional = true
+
+  [[order.group]]
+    id = "renku/homebrew"
+    version = "0.8.0"
+    optional = true
+
+  [[order.group]]
+    id = "renku/init-scripts"
+    version = "0.8.0"
+    optional = true
+
+  [[order.group]]
+    id = "paketo-buildpacks/node-engine"
+    version = "8.1.1"
+    optional = true
+
+  [[order.group]]
+    id = "renku/coding-agent"
+    version = "0.8.0"
+    optional = true
+
+[[order]]
+
+  [[order.group]]
+    id = "renku/conda-nodefaults"
+    version = "0.8.0"
+    optional = true
+
+  [[order.group]]
+    id = "renku/renku-variables"
+    version = "0.8.0"
+
+  [[order.group]]
+    id = "paketo-buildpacks/miniconda"
+    version = "0.11.22"
+
+  [[order.group]]
+    id = "renku/r-dependency-manager-conda"
+    version = "0.8.0"
+
+  [[order.group]]
+    id = "renku/none-frontend"
     version = "0.8.0"
 
   [[order.group]]

--- a/builders/selector/builder.toml
+++ b/builders/selector/builder.toml
@@ -25,6 +25,10 @@ description = "Builder for Renku frontends and environments."
   version = "0.8.0"
 
 [[buildpacks]]
+  uri = "../../buildpacks/none-frontend"
+  version = "0.8.0"
+
+[[buildpacks]]
   uri = "../../buildpacks/python-dependency-manager"
   version = "0.8.0"
 
@@ -108,6 +112,54 @@ description = "Builder for Renku frontends and environments."
 
   [[order.group]]
     id = "renku/kernel-installer"
+    version = "0.8.0"
+
+  [[order.group]]
+    id = "heroku/deb-packages"
+    version = "0.2.0"
+    optional = true
+
+  [[order.group]]
+    id = "renku/homebrew"
+    version = "0.8.0"
+    optional = true
+
+  [[order.group]]
+    id = "renku/init-scripts"
+    version = "0.8.0"
+    optional = true
+
+  [[order.group]]
+    id = "paketo-buildpacks/node-engine"
+    version = "8.1.1"
+    optional = true
+
+  [[order.group]]
+    id = "renku/coding-agent"
+    version = "0.8.0"
+    optional = true
+
+[[order]]
+
+  [[order.group]]
+    id = "renku/conda-nodefaults"
+    version = "0.8.0"
+    optional = true
+
+  [[order.group]]
+    id = "paketo-buildpacks/python"
+    version = "2.46.0"
+
+  [[order.group]]
+    id = "renku/python-dependency-manager"
+    version = "0.8.0"
+
+  [[order.group]]
+    id = "renku/renku-variables"
+    version = "0.8.0"
+
+  [[order.group]]
+    id = "renku/none-frontend"
     version = "0.8.0"
 
   [[order.group]]
@@ -303,6 +355,95 @@ description = "Builder for Renku frontends and environments."
 
   [[order.group]]
     id = "renku/rstudio"
+    version = "0.8.0"
+
+  [[order.group]]
+    id = "heroku/deb-packages"
+    version = "0.2.0"
+    optional = true
+
+  [[order.group]]
+    id = "renku/homebrew"
+    version = "0.8.0"
+    optional = true
+
+  [[order.group]]
+    id = "renku/init-scripts"
+    version = "0.8.0"
+    optional = true
+
+[[order]]
+
+  [[order.group]]
+    id = "renku/renku-variables"
+    version = "0.8.0"
+
+  [[order.group]]
+    id = "paketo-buildpacks/miniconda"
+    version = "0.11.22"
+
+  [[order.group]]
+    id = "renku/r-conda"
+    version = "0.8.0"
+
+  [[order.group]]
+    id = "renku/renv"
+    version = "0.8.0"
+
+  [[order.group]]
+    id = "renku/r-dependency-manager"
+    version = "0.8.0"
+
+  [[order.group]]
+    id = "renku/none-frontend"
+    version = "0.8.0"
+
+  [[order.group]]
+    id = "heroku/deb-packages"
+    version = "0.2.0"
+    optional = true
+
+  [[order.group]]
+    id = "renku/homebrew"
+    version = "0.8.0"
+    optional = true
+
+  [[order.group]]
+    id = "renku/init-scripts"
+    version = "0.8.0"
+    optional = true
+
+  [[order.group]]
+    id = "paketo-buildpacks/node-engine"
+    version = "8.1.1"
+    optional = true
+
+  [[order.group]]
+    id = "renku/coding-agent"
+    version = "0.8.0"
+    optional = true
+
+[[order]]
+
+  [[order.group]]
+    id = "renku/conda-nodefaults"
+    version = "0.8.0"
+    optional = true
+
+  [[order.group]]
+    id = "renku/renku-variables"
+    version = "0.8.0"
+
+  [[order.group]]
+    id = "paketo-buildpacks/miniconda"
+    version = "0.11.22"
+
+  [[order.group]]
+    id = "renku/r-dependency-manager-conda"
+    version = "0.8.0"
+
+  [[order.group]]
+    id = "renku/none-frontend"
     version = "0.8.0"
 
   [[order.group]]

--- a/buildpacks/none-frontend/bin/build
+++ b/buildpacks/none-frontend/bin/build
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -eou pipefail
+
+echo -e "=== ✨ \033[1mRenku Empty Frontend buildpack\033[0m ==="
+echo  "No frontend will be implicitely included"
+echo  "if you require something served ensure to launch it from the Procfile"

--- a/buildpacks/none-frontend/bin/detect
+++ b/buildpacks/none-frontend/bin/detect
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+if [[ "${BP_RENKU_FRONTENDS}" =~ "none" ]]; then
+  echo "PASS: The BP_RENKU_FRONTENDS environment variable was found to contain none."
+else
+  echo "SKIPPED: The BP_RENKU_FRONTENDS environment variable is not set or does not contain none."
+  exit 100
+fi

--- a/buildpacks/none-frontend/buildpack.toml
+++ b/buildpacks/none-frontend/buildpack.toml
@@ -1,0 +1,14 @@
+api = "0.11"
+
+[[targets]]
+  arch = "amd64"
+  os = "linux"
+
+[[targets]]
+  arch = "arm64"
+  os = "linux"
+
+[buildpack]
+  id = "renku/none-frontend"
+  name = "Empty frontend Buildpack"
+  version = "0.8.0"

--- a/buildpacks/none-frontend/package.toml
+++ b/buildpacks/none-frontend/package.toml
@@ -1,0 +1,2 @@
+[buildpack]
+  uri = "."


### PR DESCRIPTION
## Summary

Create a None front-end. It effectively acts as a no-op when `BP_RENKU_FRONTENDS` is `none` 

## Planned follow-up

Add a stage when the front-end is none that detects whether a user added front-end is added. The first step will be adding `marimo` detection.

closes #173 