### PR TITLE
fix: go-version in ci action

### DIFF
--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -151,7 +151,7 @@ jobs:
 
     - uses: actions/setup-go@v6
       with:
-        go-version: '1.23'
+        go-version: '1.25'
 
     - name: Update buildpack.toml versions
       run: make update-buildpack-versions RELEASE_VERSION=${{ github.event.inputs.version }}${{ (github.event.inputs.test_mode == 'true' && '-test') || '' }}

--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -150,6 +150,8 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - uses: actions/setup-go@v6
+      with:
+        go-version: '1.23'
 
     - name: Update buildpack.toml versions
       run: make update-buildpack-versions RELEASE_VERSION=${{ github.event.inputs.version }}${{ (github.event.inputs.test_mode == 'true' && '-test') || '' }}


### PR DESCRIPTION
the release process fails because of the go version. this fixes it